### PR TITLE
#87 Connect Sign-Up & OTP Verification Screens to Backend Authentication Endpoints

### DIFF
--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -3,12 +3,14 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Eye, EyeOff } from "lucide-react";
+import { signUp } from "@/lib/api/auth";
 
 export default function CreateAccountPage() {
   const router = useRouter();
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [apiError, setApiError] = useState("");
 
   const [formData, setFormData] = useState({
     email: "",
@@ -45,11 +47,20 @@ export default function CreateAccountPage() {
     if (!validate()) return;
 
     setIsLoading(true);
-    // Simulate API call
-    setTimeout(() => {
-      setIsLoading(false);
+    setApiError("");
+    try {
+      await signUp({
+        email: formData.email,
+        phone: formData.phone,
+        password: formData.password,
+      });
+      sessionStorage.setItem("signup_email", formData.email);
       router.push("/signup/verify");
-    }, 1500);
+    } catch (err) {
+      setApiError(err instanceof Error ? err.message : "Something went wrong");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -175,6 +186,9 @@ export default function CreateAccountPage() {
           </label>
         </div>
 
+        {apiError && (
+          <p className="text-xs text-red-500 text-center">{apiError}</p>
+        )}
         <button
           type="submit"
           disabled={isLoading || !formData.acceptTerms}

--- a/lib/api/auth.ts
+++ b/lib/api/auth.ts
@@ -1,0 +1,32 @@
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL;
+
+async function request<T>(path: string, body: object): Promise<T> {
+  const res = await fetch(`${BASE_URL}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data?.message || res.statusText);
+  }
+
+  return res.json();
+}
+
+export function signUp(payload: {
+  email: string;
+  phone: string;
+  password: string;
+}) {
+  return request("/auth/signup", payload);
+}
+
+export function verifySignupOtp(payload: { email: string; otp: string }) {
+  return request("/auth/verify-signup-otp", payload);
+}
+
+export function resendSignupOtp(payload: { email: string }) {
+  return request("/auth/resend-signup-otp", payload);
+}


### PR DESCRIPTION
feat: connect signup & OTP verification screens to backend auth endpoints
Closes #87

Summary
The signup flow previously used setTimeout() to fake backend responses across all screens. This PR replaces every simulation with real API calls to the NexaFX authentication endpoints, wires the Resend OTP button, persists the user's email between pages, and handles loading and error states throughout.

Changes

lib/api/auth.ts
 (new file)

A shared, reusable API client for the signup flow:

Private request<T>() helper — uses native fetch, sets Content-Type: application/json, and throws an Error with the server's message field on non-2xx responses (falls back to HTTP status text)
Base URL read from process.env.NEXT_PUBLIC_API_URL
Three typed exports:

signUp({ email, phone, password })
 → POST /auth/signup

verifySignupOtp({ email, otp })
 → POST /auth/verify-signup-otp

resendSignupOtp({ email })
 → POST /auth/resend-signup-otp

app/signup/page.tsx

Added import { signUp } from "@/lib/api/auth"
Added apiError state string

handleSubmit
 — removed setTimeout, replaced with try/catch/finally:
Calls 

signUp({ email, phone, password })
On success: stores email in sessionStorage under key "signup_email" then navigates to /signup/verify
On error: populates apiError with the message from the API response
setIsLoading(false) always runs in finally
apiError rendered as a red paragraph above the submit button

app/signup/verify/page.tsx

Added import { verifySignupOtp, resendSignupOtp } from "@/lib/api/auth"
Added state: apiError, resendMessage, isResending, email
useEffect — reads sessionStorage.getItem("signup_email") into email on mount (alongside the existing first-input focus)

handleSubmit
 — removed setTimeout, replaced with try/catch/finally:
Calls 

verifySignupOtp({ email, otp: otp.join("") })
On success: navigates to /signup/success
On error: sets apiError with the server message or "Invalid or expired OTP"
New 

handleResend()
 async function:
Sets isResending(true), clears prior messages
Calls 

resendSignupOtp({ email })
On success: sets resendMessage to "Code resent successfully"
On error: sets apiError with the failure message
setIsResending(false) always runs in finally
Resend <button> wired to onClick={handleResend}, disabled={isResending}, shows "Resending..." label during in-flight request
apiError (red) and resendMessage (green) rendered above the submit button
How to test
Add NEXT_PUBLIC_API_URL=<backend-url> to .env.local
npm run dev
Happy path — fill in valid credentials on /signup, submit → network request to /auth/signup appears, redirects to /signup/verify
Enter the OTP received by email → network request to /auth/verify-signup-otp, redirects to /signup/success
Error path — enter wrong OTP → inline error message shown, no crash
Click Resend → request to /auth/resend-signup-otp, "Code resent successfully" shown; button is disabled and shows "Resending..." during the call
Offline/backend down — submit on any screen → error message from API shown inline
