### PR TITLE
feat: Connect Notifications Page and Store to Backend

### DIFF
--- a/app/(dashboard)/notifications/page.tsx
+++ b/app/(dashboard)/notifications/page.tsx
@@ -3,17 +3,33 @@
 import { useEffect } from "react";
 import { useNotificationsStore } from "@/hooks/use-notifications-store";
 import { SwipeableNotificationItem } from "@/components/notifications";
-import { mockNotifications } from "@/lib/mock-notifications";
+
+function NotificationSkeleton() {
+  return (
+    <div className="flex items-start gap-3 p-4 animate-pulse">
+      <div className="h-9 w-9 rounded-full bg-muted shrink-0" />
+      <div className="flex-1 space-y-2">
+        <div className="h-3.5 w-1/3 rounded bg-muted" />
+        <div className="h-3 w-2/3 rounded bg-muted" />
+        <div className="h-3 w-1/4 rounded bg-muted" />
+      </div>
+    </div>
+  );
+}
 
 export default function NotificationsPage() {
-  const { notifications, setNotifications, markAsRead, removeNotification } =
-    useNotificationsStore();
+  const {
+    notifications,
+    isLoading,
+    error,
+    fetchNotifications,
+    markAsRead,
+    removeNotification,
+  } = useNotificationsStore();
 
   useEffect(() => {
-    if (notifications.length === 0) {
-      setNotifications(mockNotifications);
-    }
-  }, [notifications.length, setNotifications]);
+    fetchNotifications();
+  }, [fetchNotifications]);
 
   const handleNotificationClick = (id: string) => {
     markAsRead(id);
@@ -26,7 +42,17 @@ export default function NotificationsPage() {
   return (
     <div className="max-w-2xl mx-auto">
       <div className="bg-card rounded-xl border border-border overflow-hidden">
-        {notifications.length === 0 ? (
+        {isLoading ? (
+          <div className="divide-y divide-border">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <NotificationSkeleton key={i} />
+            ))}
+          </div>
+        ) : error ? (
+          <div className="p-8 text-center text-destructive">
+            <p>{error}</p>
+          </div>
+        ) : notifications.length === 0 ? (
           <div className="p-8 text-center text-muted-foreground">
             <p>No notifications yet</p>
           </div>

--- a/components/dashboard/topbar.tsx
+++ b/components/dashboard/topbar.tsx
@@ -7,7 +7,6 @@ import Link from "next/link";
 import { useSidebarStore } from "@/hooks/use-sidebar-store";
 import { useNotificationsStore } from "@/hooks/use-notifications-store";
 import { NotificationsPanel } from "@/components/notifications";
-import { mockNotifications } from "@/lib/mock-notifications";
 
 export function Topbar() {
   const pathname = usePathname();
@@ -22,18 +21,14 @@ export function Topbar() {
   });
 
   const {
-    notifications,
-    setNotifications,
     unreadCount,
+    fetchUnreadCount,
     toggle: toggleNotifications,
   } = useNotificationsStore();
 
   useEffect(() => {
-    // Initialize notifications with mock data
-    if (notifications.length === 0) {
-      setNotifications(mockNotifications);
-    }
-  }, [notifications.length, setNotifications]);
+    fetchUnreadCount();
+  }, [fetchUnreadCount]);
 
   const toggleTheme = () => {
     const newMode = !isDarkMode;

--- a/components/notifications/notifications-panel.tsx
+++ b/components/notifications/notifications-panel.tsx
@@ -1,14 +1,45 @@
 "use client";
 
+import { useEffect } from "react";
 import { Settings } from "lucide-react";
 import Link from "next/link";
 import { useNotificationsStore } from "@/hooks/use-notifications-store";
 import { NotificationItem } from "./notification-item";
 import { Checkbox } from "@/components/ui/checkbox";
 
+function PanelSkeleton() {
+  return (
+    <div className="divide-y divide-border">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="flex items-start gap-3 p-4 animate-pulse">
+          <div className="h-9 w-9 rounded-full bg-muted shrink-0" />
+          <div className="flex-1 space-y-2">
+            <div className="h-3.5 w-1/3 rounded bg-muted" />
+            <div className="h-3 w-2/3 rounded bg-muted" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export function NotificationsPanel() {
-  const { notifications, isOpen, close, markAsRead, markAllAsRead, unreadCount } =
-    useNotificationsStore();
+  const {
+    notifications,
+    isOpen,
+    isLoading,
+    close,
+    markAsRead,
+    markAllAsRead,
+    fetchNotifications,
+    unreadCount,
+  } = useNotificationsStore();
+
+  useEffect(() => {
+    if (isOpen) {
+      fetchNotifications();
+    }
+  }, [isOpen, fetchNotifications]);
 
   if (!isOpen) return null;
 
@@ -23,16 +54,15 @@ export function NotificationsPanel() {
   return (
     <>
       {/* Backdrop */}
-      <div
-        className="fixed inset-0 z-40"
-        onClick={close}
-      />
+      <div className="fixed inset-0 z-40" onClick={close} />
 
       {/* Panel */}
-      <div className="absolute top-full right-0 mt-2 w-[400px] bg-card rounded-xl shadow-lg border border-border z-50 overflow-hidden animate-in fade-in slide-in-from-top-2 duration-200">
+      <div className="absolute top-full right-0 mt-2 w-100 bg-card rounded-xl shadow-lg border border-border z-50 overflow-hidden animate-in fade-in slide-in-from-top-2 duration-200">
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-border">
-          <h3 className="text-base font-semibold text-foreground">Notifications</h3>
+          <h3 className="text-base font-semibold text-foreground">
+            Notifications
+          </h3>
           <div className="flex items-center gap-3">
             <label className="flex items-center gap-2 text-sm text-muted-foreground cursor-pointer">
               <Checkbox
@@ -55,8 +85,10 @@ export function NotificationsPanel() {
         </div>
 
         {/* Notifications List */}
-        <div className="max-h-[400px] overflow-y-auto">
-          {notifications.length === 0 ? (
+        <div className="max-h-100 overflow-y-auto">
+          {isLoading ? (
+            <PanelSkeleton />
+          ) : notifications.length === 0 ? (
             <div className="p-8 text-center text-muted-foreground">
               <p>No notifications yet</p>
             </div>

--- a/hooks/use-notifications-store.ts
+++ b/hooks/use-notifications-store.ts
@@ -1,10 +1,13 @@
 import { create } from "zustand";
 import { Notification } from "@/types/notification";
+import * as api from "@/lib/api/notifications";
 
 interface NotificationsStore {
   notifications: Notification[];
   isOpen: boolean;
   unreadCount: number;
+  isLoading: boolean;
+  error: string | null;
 
   // Panel actions
   open: () => void;
@@ -13,6 +16,8 @@ interface NotificationsStore {
 
   // Notification actions
   setNotifications: (notifications: Notification[]) => void;
+  fetchNotifications: () => Promise<void>;
+  fetchUnreadCount: () => Promise<void>;
   markAsRead: (id: string) => void;
   markAllAsRead: () => void;
   addNotification: (notification: Notification) => void;
@@ -23,6 +28,8 @@ export const useNotificationsStore = create<NotificationsStore>((set, get) => ({
   notifications: [],
   isOpen: false,
   unreadCount: 0,
+  isLoading: false,
+  error: null,
 
   open: () => set({ isOpen: true }),
   close: () => set({ isOpen: false }),
@@ -34,7 +41,32 @@ export const useNotificationsStore = create<NotificationsStore>((set, get) => ({
       unreadCount: notifications.filter((n) => !n.isRead).length,
     }),
 
-  markAsRead: (id) =>
+  fetchNotifications: async () => {
+    set({ isLoading: true, error: null });
+    try {
+      const notifications = await api.getNotifications();
+      set({
+        notifications,
+        unreadCount: notifications.filter((n) => !n.isRead).length,
+        isLoading: false,
+      });
+    } catch (err) {
+      set({
+        isLoading: false,
+        error: err instanceof Error ? err.message : "Failed to load notifications",
+      });
+    }
+  },
+
+  fetchUnreadCount: async () => {
+    try {
+      const count = await api.getUnreadCount();
+      set({ unreadCount: count });
+    } catch {
+    }
+  },
+
+  markAsRead: (id) => {
     set((state) => {
       const updated = state.notifications.map((n) =>
         n.id === id ? { ...n, isRead: true } : n
@@ -43,13 +75,17 @@ export const useNotificationsStore = create<NotificationsStore>((set, get) => ({
         notifications: updated,
         unreadCount: updated.filter((n) => !n.isRead).length,
       };
-    }),
+    });
+    api.markAsRead(id).catch(() => {});
+  },
 
-  markAllAsRead: () =>
+  markAllAsRead: () => {
     set((state) => ({
       notifications: state.notifications.map((n) => ({ ...n, isRead: true })),
       unreadCount: 0,
-    })),
+    }));
+    api.markAllAsRead().catch(() => {});
+  },
 
   addNotification: (notification) =>
     set((state) => ({
@@ -57,7 +93,7 @@ export const useNotificationsStore = create<NotificationsStore>((set, get) => ({
       unreadCount: state.unreadCount + (notification.isRead ? 0 : 1),
     })),
 
-  removeNotification: (id) =>
+  removeNotification: (id) => {
     set((state) => {
       const notification = state.notifications.find((n) => n.id === id);
       const updated = state.notifications.filter((n) => n.id !== id);
@@ -66,5 +102,7 @@ export const useNotificationsStore = create<NotificationsStore>((set, get) => ({
         unreadCount:
           state.unreadCount - (notification && !notification.isRead ? 1 : 0),
       };
-    }),
+    });
+    api.deleteNotification(id).catch(() => {});
+  },
 }));

--- a/lib/api/notifications.ts
+++ b/lib/api/notifications.ts
@@ -1,0 +1,58 @@
+import { Notification } from "@/types/notification";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "";
+
+function getAuthHeaders(): HeadersInit {
+  const token =
+    typeof window !== "undefined" ? localStorage.getItem("token") : null;
+  return {
+    "Content-Type": "application/json",
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
+}
+
+export async function getNotifications(
+  page = 1,
+  limit = 20
+): Promise<Notification[]> {
+  const res = await fetch(
+    `${API_BASE}/notifications?page=${page}&limit=${limit}`,
+    { headers: getAuthHeaders() }
+  );
+  if (!res.ok) throw new Error("Failed to fetch notifications");
+  const data = await res.json();
+  return Array.isArray(data) ? data : (data.data ?? data.notifications ?? []);
+}
+
+export async function markAsRead(id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/notifications/${id}/read`, {
+    method: "PATCH",
+    headers: getAuthHeaders(),
+  });
+  if (!res.ok) throw new Error("Failed to mark notification as read");
+}
+
+export async function markAllAsRead(): Promise<void> {
+  const res = await fetch(`${API_BASE}/notifications/batch/mark-all-read`, {
+    method: "PATCH",
+    headers: getAuthHeaders(),
+  });
+  if (!res.ok) throw new Error("Failed to mark all notifications as read");
+}
+
+export async function deleteNotification(id: string): Promise<void> {
+  const res = await fetch(`${API_BASE}/notifications/${id}`, {
+    method: "DELETE",
+    headers: getAuthHeaders(),
+  });
+  if (!res.ok) throw new Error("Failed to delete notification");
+}
+
+export async function getUnreadCount(): Promise<number> {
+  const res = await fetch(`${API_BASE}/notifications/unread-count`, {
+    headers: getAuthHeaders(),
+  });
+  if (!res.ok) throw new Error("Failed to fetch unread count");
+  const data = await res.json();
+  return data.count ?? data.unreadCount ?? 0;
+}


### PR DESCRIPTION
feat: Connect Notifications Page and Store to Backend
                                                                 
  📋 Description                                                                                                        
  Replaces mock notification data with real API calls. The Zustand store now fetches from the backend on mount, and all
  mutation actions (mark as read, mark all as read, delete) persist to the backend with optimistic UI updates.

  🛠  Changes Implemented

  - Created lib/api/notifications.ts with typed functions: getNotifications, markAsRead, markAllAsRead,
  deleteNotification, getUnreadCount
  - Extended useNotificationsStore with fetchNotifications, fetchUnreadCount, isLoading, and error state
  - Mutation actions (markAsRead, markAllAsRead, removeNotification) now call the API in the background after optimistic
   local updates
  - Updated notifications page to call fetchNotifications() on mount with animated loading skeleton
  - Updated NotificationsPanel to fetch notifications when opened, with loading skeleton
  - Updated topbar to call fetchUnreadCount() on mount — badge now reflects real backend data
  - JWT token read from localStorage and passed as Authorization: Bearer <token> on all requests
  - Removed mockNotifications import from topbar and notifications page

  ✅ How to Test

  1. Setup: Set NEXT_PUBLIC_API_URL in .env.local to point to the backend. Ensure a valid JWT token is stored in
  localStorage under the key token.
  2. Run: bun run dev
  3. Expected Output:
    - Notifications page shows a skeleton while loading, then renders real notifications
    - Clicking a notification marks it as read and persists to the backend
    - "Mark all as read" updates all notifications and calls PATCH /notifications/batch/mark-all-read
    - Swiping/deleting a notification calls DELETE /notifications/:id
    - Bell badge in the topbar reflects the real unread count from GET /notifications/unread-count
    - Opening the desktop notification panel triggers a fresh fetch

  🔍 Screenshots (if applicable)
  
<img width="1366" height="698" alt="Screenshot (1586)" src="https://github.com/user-attachments/assets/6abe5409-3482-472b-a4c5-f0c9b5c11960" />


  Loading skeleton visible on notifications page and panel while fetching.

  🚀 Checklist

  - Code follows project style guidelines.
  - Changes are tested and verified.
  - Documentation is updated (if needed).

  🔗 Related Issues

  - Closes #90