### PR TITLE
feat: #177 Secure DEV_TOKEN proxy with NODE_ENV guard and add .env.ex…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,20 @@ NEXT_PUBLIC_API_URL=http://localhost:3001
 
 # MoonPay publishable API key — get yours at https://dashboard.moonpay.com
 NEXT_PUBLIC_MOONPAY_API_KEY=your_moonpay_publishable_key_here
+
+# LOCAL DEVELOPMENT ONLY — DO NOT SET THIS IN STAGING OR PRODUCTION
+#
+# SECURITY WARNING: TEST_ACCESS_TOKEN is used as a fallback token in the API proxy,
+# but ONLY when NODE_ENV === "development".
+#
+# If this variable is set in any deployed environment (staging, production, etc.)
+# without the NODE_ENV guard, all proxy requests from unauthenticated users will be
+# authorized using this token. This would leak real data including:
+# - Transaction history
+# - Personal notifications
+# - User profile information
+# - Any other protected API endpoints
+#
+# This also masks authentication failures, making the auth guard appear to work
+# when it does not. NEVER set TEST_ACCESS_TOKEN on Render or production deployments.
+TEST_ACCESS_TOKEN=

--- a/app/api/proxy/[...path]/route.ts
+++ b/app/api/proxy/[...path]/route.ts
@@ -1,8 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
 
 const BACKEND_URL = process.env.NEXT_PUBLIC_API_URL ?? "";
-// Injected server-side for local dev testing — replace with real auth once login flow exists
-const DEV_TOKEN = process.env.TEST_ACCESS_TOKEN ?? "";
+
+/**
+ * DEV_TOKEN: LOCAL DEVELOPMENT ONLY
+ * 
+ * This fallback token is ONLY used in local development (NODE_ENV === "development").
+ * It must NEVER be set in staging, production, or any deployed environment.
+ * 
+ * If TEST_ACCESS_TOKEN is set in a deployed environment without this guard,
+ * all proxy requests from unauthenticated users would be authorized using that token,
+ * leaking real data including transactions, notifications, and other sensitive information.
+ * 
+ * SECURITY RISK: Setting TEST_ACCESS_TOKEN on Render staging/production without
+ * this NODE_ENV check would allow unauthenticated API requests to succeed.
+ */
+const DEV_TOKEN = process.env.NODE_ENV === "development"
+  ? (process.env.TEST_ACCESS_TOKEN ?? "")
+  : "";
 
 async function handler(req: NextRequest, { params }: { params: Promise<{ path: string[] }> }) {
     const { path } = await params;


### PR DESCRIPTION
Closes #177 

## 🔒 Security Fix: DEV_TOKEN Proxy Fallback Restriction

This PR addresses a critical security vulnerability where the API proxy could authorize unauthenticated requests using a development token in production/staging environments.

## Problem
The proxy had a DEV_TOKEN fallback that would be used for all requests if set, regardless of environment. If `TEST_ACCESS_TOKEN` was accidentally deployed on Render or production, every request from unauthenticated users would be authorized, leaking:
- Transaction history
- Personal notifications  
- Sensitive user data
- Any protected API endpoints

## Solution
✅ Added `NODE_ENV === "development"` guard to DEV_TOKEN fallback
✅ Added security warning to `.env.example`
✅ Added detailed JSDoc documentation in proxy source

## Changes
- **app/api/proxy/[...path]/route.ts**: NODE_ENV guard + security documentation
- **.env.example**: Security warning comment on TEST_ACCESS_TOKEN

## Testing
- Local dev (NODE_ENV=development): DEV_TOKEN works as before ✓
- Production (NODE_ENV=production): DEV_TOKEN ignored, requests fail 401 ✓
- Existing authenticated requests: Unaffected ✓

## Acceptance Criteria
- [x] DEV_TOKEN only active when NODE_ENV === "development"
- [x] .env.example has clear warning comment
- [x] Security implications documented in source
- [x] Local dev workflows unaffected