### PR TITLE
Fix wallet balances endpoint

### DIFF
--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -2,5 +2,5 @@ import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return twMerge(clsx(inputs)); 
 }

--- a/app/signup/verify/page.tsx
+++ b/app/signup/verify/page.tsx
@@ -1,4 +1,4 @@
-"use client";
+"use client"; 
 
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";

--- a/lib/api/wallet.ts
+++ b/lib/api/wallet.ts
@@ -7,7 +7,10 @@ export interface WalletBalance {
 
 export async function getBalances(): Promise<WalletBalance[]> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const data = await apiClient<any>("/wallets/balances", {
+  // The correct backend route is `/users/wallet/balances` (not `/wallets/balances`).
+  // This route is protected and should be called directly (no proxy) —
+  // other authenticated user endpoints use `useProxy: false` as well.
+  const data = await apiClient<any>("/users/wallet/balances", {
     method: "GET",
     useProxy: false,
   });

--- a/lib/api/wallet.ts
+++ b/lib/api/wallet.ts
@@ -6,10 +6,10 @@ export interface WalletBalance {
 }
 
 export async function getBalances(): Promise<WalletBalance[]> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   // The correct backend route is `/users/wallet/balances` (not `/wallets/balances`).
   // This route is protected and should be called directly (no proxy) —
   // other authenticated user endpoints use `useProxy: false` as well.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const data = await apiClient<any>("/users/wallet/balances", {
     method: "GET",
     useProxy: false,


### PR DESCRIPTION
Fix wallet balances endpoint path

Updated wallet balances API endpoint from /wallets/balances to /users/wallet/balances in lib/api/wallet.ts
 to fix 404 errors.