### PR TITLE
fix: forward auth token in exchange-rates route

### DIFF
--- a/app/api/exchange-rates/route.ts
+++ b/app/api/exchange-rates/route.ts
@@ -14,10 +14,21 @@ export async function GET(req: NextRequest) {
 
     try {
         const BASE_URL = process.env.NEXT_PUBLIC_API_URL || "https://nexafx-backend.onrender.com/v1";
+
+        // Forward the caller's token when present. The backend may treat /exchange-rates
+        // as public or optionally authenticated (e.g. for personalised rates); unauthenticated
+        // requests still proceed without an Authorization header.
+        const token =
+            req.headers.get("x-client-token") ??
+            req.cookies.get("access_token")?.value;
+
+        const headers = new Headers({ "Content-Type": "application/json" });
+        if (token) {
+            headers.set("Authorization", `Bearer ${token}`);
+        }
+
         const externalRes = await fetch(`${BASE_URL}/exchange-rates?from=${from}&to=${to}`, {
-            headers: {
-                "Content-Type": "application/json",
-            },
+            headers,
         });
 
         if (!externalRes.ok) {
@@ -30,7 +41,7 @@ export async function GET(req: NextRequest) {
 
         const data = await externalRes.json();
         return NextResponse.json(data);
-} catch (error: unknown) {
+    } catch (error: unknown) {
         return NextResponse.json(
             { error: error instanceof Error ? error.message : 'Failed to fetch exchange rates' },
             { status: 500 }

--- a/lib/api/exchange-rates.ts
+++ b/lib/api/exchange-rates.ts
@@ -1,7 +1,15 @@
 export async function getExchangeRate(from: string, to: string) {
+    const token =
+        typeof window !== "undefined" ? localStorage.getItem("access_token") : null;
+
+    const headers = new Headers({ "Content-Type": "application/json" });
+    if (token) {
+        headers.set("x-client-token", token);
+    }
+
     const res = await fetch(`/api/exchange-rates?from=${from}&to=${to}`, {
         method: "GET",
-        headers: { "Content-Type": "application/json" },
+        headers,
     });
 
     if (!res.ok) {


### PR DESCRIPTION
- Forward `x-client-token` / `access_token` cookie as `Authorization: Bearer` in `/api/exchange-rates`
- Send `x-client-token` from `getExchangeRate()` so logged-in users pass their token through
Closes #174