### PR TITLE
fix

### DIFF
--- a/app/(auth)/verify-otp/page.tsx
+++ b/app/(auth)/verify-otp/page.tsx
@@ -72,8 +72,9 @@ export default function VerifyOtpPage() {
     setIsLoading(true);
     setError('');
     try {
-      const res = await verifyLoginOtp({ email: storedEmail, otp: otpCode }) as { user: { id: string; name: string; email: string; role: 'USER' | 'ADMIN' }; accessToken: string; refreshToken: string };
-      setAuth(res.user, res.accessToken, res.refreshToken);
+      const res = await verifyLoginOtp({ email: storedEmail, otp: otpCode }) as { user: { id: string; firstName: string; lastName: string; email: string; role: 'USER' | 'ADMIN' }; accessToken: string; refreshToken: string };
+      const fullName = [res.user.firstName, res.user.lastName].filter(Boolean).join(' ');
+      setAuth({ ...res.user, name: fullName }, res.accessToken, res.refreshToken);
       setIsLoading(false);
       router.push('/dashboard');
     } catch (err: unknown) {

--- a/components/profile/profile-edit-form.tsx
+++ b/components/profile/profile-edit-form.tsx
@@ -48,6 +48,8 @@ export function ProfileEditForm() {
       setAuth(
         {
           id: updated.id,
+          firstName: updated.firstName,
+          lastName: updated.lastName,
           name: `${updated.firstName} ${updated.lastName}`,
           email: updated.email,
           role: 'USER',

--- a/components/profile/profile-overview.tsx
+++ b/components/profile/profile-overview.tsx
@@ -24,6 +24,8 @@ export function ProfileOverview() {
           setAuth(
             {
               id: data.id,
+              firstName: data.firstName,
+              lastName: data.lastName,
               name: `${data.firstName} ${data.lastName}`,
               email: data.email,
               role: 'USER',

--- a/hooks/use-auth-store.ts
+++ b/hooks/use-auth-store.ts
@@ -13,7 +13,9 @@ export interface UserProfileStore {
 
 interface User {
   id: string;
-  name: string;
+  firstName: string;
+  lastName: string;
+  name: string; // derived from firstName + lastName
   email: string;
   role: "USER" | "ADMIN";
   // Optionally add more fields if needed


### PR DESCRIPTION
## PR Description

### Summary
Fixes a login bug where `user.name` in the Zustand auth store was stored as `undefined` after OTP verification. The backend returns `firstName` and `lastName`, not a flat `name` field, so the login response was being incorrectly cast.

### What changed
- Updated use-auth-store.ts
  - `User` now includes:
    - `firstName`
    - `lastName`
    - `name` (derived display name)
- Updated OTP verification flow in page.tsx
  - Changed response typing to match backend shape
  - Derived full `name` from `firstName` + `lastName`
  - Passed the full user object into `setAuth(...)`
- Updated profile auth writes in:
  - profile-overview.tsx
  - profile-edit-form.tsx
  - These now also set `firstName`, `lastName`, and derived `name`

### Result
- `user.name` is now populated with the correct full display name after login
- Display name references across the app will render correctly
- No TypeScript errors introduced in modified files

### Files changed
- use-auth-store.ts
- page.tsx
- profile-overview.tsx
- profile-edit-form.tsx

closes #172 