### PR TITLE
fix: consolidate duplicate TransactionPagination into single correct implementation

### DIFF
--- a/components/transactions/pagination.tsx
+++ b/components/transactions/pagination.tsx
@@ -1,67 +1,93 @@
 "use client";
 
-import { cn } from "@/lib/utils";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
-interface PaginationProps {
-    currentPage: number;
-    totalPages: number;
-    onPageChange: (page: number) => void;
-    totalItems: number;
-    itemsPerPage: number;
+interface TransactionPaginationProps {
+  currentPage: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+  totalItems: number;
+  itemsPerPage: number;
 }
 
-export function TransactionPagination({ 
-    currentPage, 
-    totalPages, 
-    onPageChange,
-    totalItems,
-    itemsPerPage
-}: PaginationProps) {
-    const startItem = ((currentPage - 1) * itemsPerPage) + 1;
-    const endItem = Math.min(currentPage * itemsPerPage, totalItems);
+export function TransactionPagination({
+  currentPage,
+  totalPages,
+  onPageChange,
+  totalItems,
+  itemsPerPage,
+}: TransactionPaginationProps) {
+  const startItem = (currentPage - 1) * itemsPerPage + 1;
+  const endItem = Math.min(currentPage * itemsPerPage, totalItems);
 
-    return (
-        <div className="flex flex-col md:flex-row items-center justify-between gap-4 py-4 px-2">
-            <p className="text-sm text-muted-foreground">
-                Showing {startItem} to {endItem} of {totalItems} entries
-            </p>
+  const getVisiblePages = () => {
+    const delta = 2;
+    const range = [];
+    const rangeWithDots = [];
 
-            <div className="flex items-center gap-2">
-                <button
-                    onClick={() => onPageChange(Math.max(1, currentPage - 1))}
-                    disabled={currentPage === 1}
-                    className="px-3 py-1 text-xs font-medium border rounded-md hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                >
-                    Previous
-                </button>
+    for (let i = Math.max(2, currentPage - delta); i <= Math.min(totalPages - 1, currentPage + delta); i++) {
+      range.push(i);
+    }
 
-                {/* Simplified page numbers for now */}
-                <div className="flex items-center gap-1">
-                    {[1, 2, 3, 4, 5].map((page) => (
-                         <button
-                            key={page}
-                            onClick={() => onPageChange(page)}
-                            className={cn(
-                                "h-7 w-7 flex items-center justify-center text-xs rounded-md transition-colors",
-                                currentPage === page 
-                                    ? "bg-orange-500 text-white font-bold" 
-                                    : "bg-muted/50 hover:bg-muted text-foreground"
-                            )}
-                        >
-                            {page}
-                        </button>
-                    ))}
-                    <span className="text-xs text-muted-foreground px-1">...</span>
-                </div>
+    if (currentPage - delta > 2) {
+      rangeWithDots.push(1, '...');
+    } else {
+      rangeWithDots.push(1);
+    }
 
-                <button
-                    onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))}
-                    disabled={currentPage === totalPages}
-                    className="px-3 py-1 text-xs font-medium border rounded-md hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                >
-                    Next
-                </button>
-            </div>
-        </div>
-    );
+    rangeWithDots.push(...range);
+
+    if (currentPage + delta < totalPages - 1) {
+      rangeWithDots.push('...', totalPages);
+    } else if (totalPages > 1) {
+      rangeWithDots.push(totalPages);
+    }
+
+    return rangeWithDots;
+  };
+
+  if (totalPages <= 1) return null;
+
+  return (
+    <div className="flex flex-col sm:flex-row items-center justify-between gap-4 mt-6 pt-4 border-t border-border">
+      <div className="text-sm text-muted-foreground">
+        Showing {startItem} to {endItem} of {totalItems} results
+      </div>
+      
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => onPageChange(currentPage - 1)}
+          disabled={currentPage === 1}
+          className="inline-flex items-center justify-center w-8 h-8 rounded-lg border border-border bg-background text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+        
+        {getVisiblePages().map((page, index) => (
+          <button
+            key={index}
+            onClick={() => typeof page === 'number' && onPageChange(page)}
+            disabled={page === '...'}
+            className={`inline-flex items-center justify-center w-8 h-8 rounded-lg text-sm font-medium transition-colors ${
+              page === currentPage
+                ? 'bg-primary text-primary-foreground'
+                : page === '...'
+                ? 'cursor-default text-muted-foreground'
+                : 'border border-border bg-background text-foreground hover:bg-muted'
+            }`}
+          >
+            {page}
+          </button>
+        ))}
+        
+        <button
+          onClick={() => onPageChange(currentPage + 1)}
+          disabled={currentPage === totalPages}
+          className="inline-flex items-center justify-center w-8 h-8 rounded-lg border border-border bg-background text-foreground hover:bg-muted disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
### Description                                                                                                  
                                                                                                                   
  #### 📝 Context                                                                                                  
                                                                                                                   
  The previous transaction pagination component had a hardcoded layout ( 1, 2, 3, 4, 5 ... ) and lacked proper     
  state-driven navigation for large datasets. This made it difficult for users to navigate effectively when they   
  have many pages of transactions.                                                                                 
                                                                                                                   
  #### 🚀 What changed                                                                                             
                                                                                                                   
  This PR updates the  TransactionPagination  component to introduce dynamic ellipsis-based pagination, along with 
  UI enhancements:                                                                                                 
                                                                                                                   
  • Dynamic Page Calculation: Implemented  getVisiblePages()  to dynamically calculate and render page numbers with
  ellipses ( ... ) based on the current page and total pages (e.g.,  1 ... 4 5 6 7 8 ... 12 ).                     
  • Icon Updates: Replaced text-based "Previous" and "Next" buttons with  ChevronLeft  and  ChevronRight  icons    
  from  lucide-react  for a cleaner, modern look.                                                                  
  • Improved Styling:                                                                                              
      • Updated buttons with proper active, hover, and disabled states (e.g., cursor not-allowed when on the first 
      or last page).                                                                                               
      • Aligned the layout so that "Showing {start} to {end} of {total} results" sits nicely on the left (or on top
      for mobile screens), and the pagination controls sit on the right.                                           
      • Refined the active state to use the primary theme color.                                                   
                                                                                                                   
                                                                                                                   
  #### 📸 Screenshots
  
<img width="1329" height="692" alt="Screenshot from 2026-06-24 16-35-13" src="https://github.com/user-attachments/assets/46ded7e7-63a4-4c0f-9baa-06407aa96a9d" />
  
  #### 🧪 How to test
  
  1. Navigate to the transactions page with a dataset large enough to trigger multiple pages (e.g., 100+ items).   
  2. Verify the text on the left updates correctly (e.g., "Showing 51 to 60 of 120 results").
  3. Click through the pages and ensure the ellipsis ( ... ) shifts correctly as you move towards the middle and   
  end of the list.
  4. Verify the Previous and Next arrows disable appropriately on the first and last pages.

## Closes #154
