### PR TITLE
closes #219 feat: build market rates overview with graceful 500 degradation

### DIFF
--- a/components/dashboard/market-overview.tsx
+++ b/components/dashboard/market-overview.tsx
@@ -2,10 +2,10 @@
 
 import {
   TrendingUp,
-  TrendingDown,
   DollarSign,
   PoundSterling,
   Euro,
+  AlertCircle,
 } from "lucide-react";
 import { useEffect, useState } from "react";
 import { getExchangeRate } from "@/lib/api/exchange-rates";
@@ -13,9 +13,8 @@ import { getExchangeRate } from "@/lib/api/exchange-rates";
 interface RateData {
   pair: string;
   rate: string;
-  change: string;
-  up: boolean;
   icon: React.ReactNode;
+  unavailable: boolean;
 }
 
 const defaultPairs = [
@@ -26,16 +25,22 @@ const defaultPairs = [
     icon: <DollarSign className="w-4 h-4" />,
   },
   {
+    to: "EUR",
+    from: "NGN",
+    pair: "NGN/EUR",
+    icon: <Euro className="w-4 h-4" />,
+  },
+  {
     to: "GBP",
     from: "NGN",
     pair: "NGN/GBP",
     icon: <PoundSterling className="w-4 h-4" />,
   },
   {
-    to: "EUR",
+    to: "BTC",
     from: "NGN",
-    pair: "NGN/EUR",
-    icon: <Euro className="w-4 h-4" />,
+    pair: "NGN/BTC",
+    icon: <span className="text-xs font-bold">₿</span>,
   },
 ];
 
@@ -45,56 +50,41 @@ export function MarketOverview() {
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
 
   const fetchRates = async () => {
-    try {
-      const results = await Promise.all(
-        defaultPairs.map(async (p) => {
-          try {
-            const res = await getExchangeRate(p.from, p.to);
-            const rateValue = res?.data?.rate ?? res?.rate ?? 0;
-            const changeValue =
-              res?.data?.change ??
-              res?.change ??
-              res?.data?.percentChange ??
-              res?.percentChange ??
-              null;
-            const isPositive =
-              changeValue !== null ? parseFloat(changeValue) > 0 : null;
-            return {
-              pair: p.pair,
-              rate: rateValue
-                ? `₦${Number(rateValue).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
-                : "N/A",
-              change:
-                changeValue !== null
-                  ? `${parseFloat(changeValue) >= 0 ? "+" : ""}${changeValue}%`
-                  : "N/A",
-              up: isPositive ?? true,
-              icon: p.icon,
-            };
-          } catch {
-            return {
-              pair: p.pair,
-              rate: "...",
-              change: "N/A",
-              up: true,
-              icon: p.icon,
-            };
-          }
-        }),
-      );
-      setMarketData(results);
-    } catch (error) {
-      console.error("Failed to fetch rates:", error);
-    } finally {
-      setLoading(false);
-      setLastUpdated(new Date());
-    }
+    const results = await Promise.all(
+      defaultPairs.map(async (p) => {
+        try {
+          const res = await getExchangeRate(p.from, p.to);
+          return {
+            pair: p.pair,
+            rate: res.rate
+              ? `₦${Number(res.rate).toLocaleString(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}`
+              : "N/A",
+            icon: p.icon,
+            unavailable: false,
+          };
+        } catch {
+          return {
+            pair: p.pair,
+            rate: "",
+            icon: p.icon,
+            unavailable: true,
+          };
+        }
+      }),
+    );
+    setMarketData(results);
+    setLoading(false);
+    setLastUpdated(new Date());
   };
 
   useEffect(() => {
     fetchRates();
     const interval = setInterval(fetchRates, 60000);
     return () => clearInterval(interval);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -117,7 +107,7 @@ export function MarketOverview() {
 
       <div className="exchange-rates flex items-center overflow-x-auto gap-3 pb-2">
         {loading && marketData.length === 0
-          ? Array.from({ length: 3 }).map((_, i) => (
+          ? Array.from({ length: 4 }).map((_, i) => (
               <div
                 key={i}
                 className="min-w-[251px] rounded-sm border-[0.43px] border-[#79797966] bg-card p-5 shadow-[4px-4px-12px-0px-#0000001A]"
@@ -146,25 +136,22 @@ export function MarketOverview() {
                   </div>
                 </div>
 
-                <div className="flex items-center justify-between gap-4 w-full">
-                  <p className="text-lg font-bold tracking-tight">
-                    {item.rate}
-                  </p>
-                  <div
-                    className={`flex items-center gap-1 text-[10px] font-bold px-2 py-0.5 rounded-full ${
-                      item.up
-                        ? "bg-green-500/10 text-green-500"
-                        : "bg-red-500/10 text-red-500"
-                    }`}
-                  >
-                    {item.up ? (
-                      <TrendingUp className="h-2.5 w-2.5" />
-                    ) : (
-                      <TrendingDown className="h-2.5 w-2.5" />
-                    )}
-                    {item.change}
+                {item.unavailable ? (
+                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    <AlertCircle className="h-3.5 w-3.5 shrink-0" />
+                    <span>Rates temporarily unavailable</span>
                   </div>
-                </div>
+                ) : (
+                  <div className="flex items-center justify-between gap-4 w-full">
+                    <p className="text-lg font-bold tracking-tight">
+                      {item.rate}
+                    </p>
+                    <div className="flex items-center gap-1 text-[10px] font-bold px-2 py-0.5 rounded-full bg-green-500/10 text-green-500">
+                      <TrendingUp className="h-2.5 w-2.5" />
+                      Live
+                    </div>
+                  </div>
+                )}
               </div>
             ))}
       </div>

--- a/lib/api/exchange-rates.ts
+++ b/lib/api/exchange-rates.ts
@@ -1,4 +1,11 @@
-export async function getExchangeRate(from: string, to: string) {
+export interface ExchangeRate {
+  from: string
+  to: string
+  rate: number
+  updatedAt: string
+}
+
+export const getExchangeRate = (from: string, to: string): Promise<ExchangeRate> => {
     const token =
         typeof window !== "undefined" ? localStorage.getItem("access_token") : null;
 
@@ -7,15 +14,14 @@ export async function getExchangeRate(from: string, to: string) {
         headers.set("x-client-token", token);
     }
 
-    const res = await fetch(`/api/exchange-rates?from=${from}&to=${to}`, {
+    return fetch(`/api/exchange-rates?from=${from}&to=${to}`, {
         method: "GET",
         headers,
+    }).then(async (res) => {
+        if (!res.ok) {
+            const data = await res.json().catch(() => ({}));
+            throw new Error(data?.error || data?.message || res.statusText);
+        }
+        return res.json();
     });
-
-    if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data?.error || data?.message || res.statusText);
-    }
-
-    return res.json();
-}
+};


### PR DESCRIPTION
Closes #219 

## Summary

- Adds `ExchangeRate` interface and typed `getExchangeRate` export in `lib/api/exchange-rates.ts`
- Extends `market-overview.tsx` to cover all four required pairs: NGN/USD, NGN/EUR, NGN/GBP, NGN/BTC
- Shows animated skeleton cards while rates are loading on first render
- Displays per-card **"Rates temporarily unavailable"** (with alert icon) when `GET /exchange-rates` returns 500 - the dashboard page continues to load and render normally
- Auto-refreshes all rates every 60 seconds via `setInterval` with cleanup on unmount
- Route handler at `app/api/exchange-rates/route.ts` reads `x-client-token` header (falling back to `access_token` cookie) and forwards it as `Authorization: Bearer` to the backend

## Test plan

- [ ] Dashboard loads fully even when exchange-rates endpoint returns 500
- [ ] Four rate cards render with skeleton pulse on initial load
- [ ] Each card shows "Rates temporarily unavailable" when the endpoint is down
- [ ] Cards show live rate values (formatted as ?x,xxx.xx) when endpoint is healthy
- [ ] Rates refresh automatically every 60 seconds
- [ ] `npm run lint` passes with no errors
- [ ] `npm run build` passes with no errors