### PR TITLE
feat: Build transaction detail modal showing full transaction info when a row is clicked

### DIFF
--- a/components/dashboard/recent-transactions.tsx
+++ b/components/dashboard/recent-transactions.tsx
@@ -13,6 +13,7 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { Transaction, getTransactions } from "@/lib/api/transactions";
 import { TransactionEmptyState } from "@/components/transactions/empty-state";
+import { TransactionDetailModal } from "./transaction-detail-modal";
 export function RecentTransactions() {
   type State =
     | { status: "loading" }
@@ -21,6 +22,8 @@ export function RecentTransactions() {
 
   const [state, setState] = useState<State>({ status: "loading" });
   const [retryCount, setRetryCount] = useState(0);
+  const [selectedTransaction, setSelectedTransaction] = useState<Transaction | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -90,104 +93,115 @@ export function RecentTransactions() {
         ) : (
           <>
             {/* Desktop view */}
-            <div className="hidden md:block overflow-x-auto">
-              <table className="w-full text-left">
-                <thead>
-                  <tr className="border-b bg-muted/30">
-                    <th className="px-6 py-4 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                      Type
-                    </th>
-                    <th className="px-6 py-4 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                      Currency
-                    </th>
-                    <th className="px-6 py-4 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                      Date
-                    </th>
-                    <th className="px-6 py-4 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
-                      Status
-                    </th>
-                    <th className="px-6 py-4 text-xs font-semibold text-muted-foreground uppercase tracking-wider text-right">
-                      Amount
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y border-border">
-                  {state.transactions.map((tx) => (
-                    <tr
-                      key={tx.id}
-                      className="hover:bg-muted/20 transition-colors"
-                    >
-                      <td className="px-6 py-4">
-                        <div className="flex items-center gap-3">
-                          <div
+              <div className="hidden md:block overflow-x-auto">
+                <table className="w-full text-left">
+                  <thead>
+                    <tr className="border-b bg-muted/30">
+                      <th className="px-6 py-4 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                        Type
+                      </th>
+                      <th className="px-6 py-4 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                        Currency
+                      </th>
+                      <th className="px-6 py-4 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                        Date
+                      </th>
+                      <th className="px-6 py-4 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                        Status
+                      </th>
+                      <th className="px-6 py-4 text-xs font-semibold text-muted-foreground uppercase tracking-wider text-right">
+                        Amount
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y border-border">
+                    {state.transactions.map((tx) => (
+                      <tr
+                        key={tx.id}
+                        className="hover:bg-muted/20 transition-colors cursor-pointer"
+                        onClick={() => {
+                          setSelectedTransaction(tx);
+                          setIsModalOpen(true);
+                        }}
+                      >
+                        <td className="px-6 py-4">
+                          <div className="flex items-center gap-3">
+                            <div
+                              className={cn(
+                                "h-8 w-8 rounded-full flex items-center justify-center",
+                                tx.type === "Deposit"
+                                  ? "bg-green-500/10 text-green-500"
+                                  : tx.type === "Withdraw"
+                                  ? "bg-red-500/10 text-red-500"
+                                  : "bg-orange-500/10 text-orange-500"
+                              )}
+                            >
+                              {tx.type === "Convert" ? (
+                                <RefreshCw className="h-4 w-4" />
+                              ) : tx.type === "Deposit" ? (
+                                <ArrowDownLeft className="h-4 w-4" />
+                              ) : (
+                                <ArrowUpRight className="h-4 w-4" />
+                              )}
+                            </div>
+                            <span className="font-medium text-foreground">
+                              {tx.type}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 text-sm text-foreground">
+                          {tx.currency}
+                          {tx.toCurrency && (
+                            <span className="text-muted-foreground">
+                              {" → "}
+                              {tx.toCurrency}
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-6 py-4 text-sm text-muted-foreground">
+                          {tx.date}
+                        </td>
+                        <td className="px-6 py-4">
+                          <span
                             className={cn(
-                              "h-8 w-8 rounded-full flex items-center justify-center",
-                              tx.type === "Deposit"
+                              "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+                              tx.status === "Success"
                                 ? "bg-green-500/10 text-green-500"
-                                : tx.type === "Withdraw"
-                                ? "bg-red-500/10 text-red-500"
-                                : "bg-orange-500/10 text-orange-500"
+                                : tx.status === "Pending"
+                                ? "bg-yellow-500/10 text-yellow-500"
+                                : "bg-red-500/10 text-red-500"
                             )}
                           >
-                            {tx.type === "Convert" ? (
-                              <RefreshCw className="h-4 w-4" />
-                            ) : tx.type === "Deposit" ? (
-                              <ArrowDownLeft className="h-4 w-4" />
-                            ) : (
-                              <ArrowUpRight className="h-4 w-4" />
-                            )}
-                          </div>
-                          <span className="font-medium text-foreground">
-                            {tx.type}
+                            {tx.status}
                           </span>
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 text-sm text-foreground">
-                        {tx.currency}
-                        {tx.toCurrency && (
-                          <span className="text-muted-foreground">
-                            {" → "}
-                            {tx.toCurrency}
-                          </span>
-                        )}
-                      </td>
-                      <td className="px-6 py-4 text-sm text-muted-foreground">
-                        {tx.date}
-                      </td>
-                      <td className="px-6 py-4">
-                        <span
+                        </td>
+                        <td
                           className={cn(
-                            "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
-                            tx.status === "Success"
-                              ? "bg-green-500/10 text-green-500"
-                              : tx.status === "Pending"
-                              ? "bg-yellow-500/10 text-yellow-500"
-                              : "bg-red-500/10 text-red-500"
+                            "px-6 py-4 text-sm font-bold text-right",
+                            tx.type === "Deposit"
+                              ? "text-green-500"
+                              : "text-foreground"
                           )}
                         >
-                          {tx.status}
-                        </span>
-                      </td>
-                      <td
-                        className={cn(
-                          "px-6 py-4 text-sm font-bold text-right",
-                          tx.type === "Deposit"
-                            ? "text-green-500"
-                            : "text-foreground"
-                        )}
-                      >
-                        {tx.amountString}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+                          {tx.amountString}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
 
             {/* Mobile view */}
             <div className="md:hidden space-y-4 p-4">
               {state.transactions.map((tx) => (
-                <div key={tx.id} className="flex items-center justify-between">
+                <div
+                  key={tx.id}
+                  className="flex items-center justify-between p-4 bg-card rounded-lg border border-border hover:bg-muted/20 transition-colors cursor-pointer"
+                  onClick={() => {
+                    setSelectedTransaction(tx);
+                    setIsModalOpen(true);
+                  }}
+                >
                   <div className="flex items-center gap-4">
                     <div
                       className={cn(
@@ -234,6 +248,14 @@ export function RecentTransactions() {
           </>
         )}
       </div>
+
+      {selectedTransaction && (
+        <TransactionDetailModal
+          transaction={selectedTransaction}
+          isOpen={isModalOpen}
+          onClose={() => setIsModalOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/components/dashboard/transaction-detail-modal.tsx
+++ b/components/dashboard/transaction-detail-modal.tsx
@@ -1,0 +1,256 @@
+import { useState, useRef } from "react";
+import { X, Copy, Check, ExternalLink, Wallet, RefreshCw } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Transaction } from "@/lib/api/transactions";
+import { useFocusTrap } from "@/hooks/use-focus-trap";
+
+interface TransactionDetailModalProps {
+  transaction: Transaction;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function TransactionDetailModal({ transaction, isOpen, onClose }: TransactionDetailModalProps) {
+  const [copied, setCopied] = useState(false);
+  const [copiedTxId, setCopiedTxId] = useState(false);
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useFocusTrap(isOpen, onClose, modalRef);
+
+  const handleCopy = (text: string, type: 'address' | 'txId') => {
+    navigator.clipboard.writeText(text);
+    setCopied(type === 'address' ? true : copied);
+    setCopiedTxId(type === 'txId' ? true : copiedTxId);
+    setTimeout(() => {
+      if (type === 'address') {
+        setCopied(false);
+      } else {
+        setCopiedTxId(false);
+      }
+    }, 2000);
+  };
+
+  if (!isOpen) return null;
+
+  const getStatusColor = (status: string) => {
+    switch (status) {
+      case "Success":
+        return "bg-green-500/10 text-green-600 border-green-200";
+      case "Pending":
+        return "bg-yellow-500/10 text-yellow-600 border-yellow-200";
+      case "Failed":
+        return "bg-red-500/10 text-red-600 border-red-200";
+      default:
+        return "bg-gray-500/10 text-gray-600 border-gray-200";
+    }
+  };
+
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case "Success":
+        return <Check className="h-3 w-3" />;
+      case "Pending":
+        return null;
+      case "Failed":
+        return <X className="h-3 w-3" />;
+      default:
+        return null;
+    }
+  };
+
+  const getTypeColor = (type: string) => {
+    switch (type) {
+      case "Deposit":
+        return "bg-green-500/10 text-green-600 border-green-200";
+      case "Withdraw":
+        return "bg-red-500/10 text-red-600 border-red-200";
+      case "Convert":
+        return "bg-orange-500/10 text-orange-600 border-orange-200";
+      default:
+        return "bg-gray-500/10 text-gray-600 border-gray-200";
+    }
+  };
+
+  const getTypeIcon = (type: string) => {
+    switch (type) {
+      case "Deposit":
+        return <Wallet className="h-4 w-4" />;
+      case "Withdraw":
+        return <RefreshCw className="h-4 w-4" />;
+      case "Convert":
+        return <ExternalLink className="h-4 w-4" />;
+      default:
+        return null;
+    }
+  };
+
+  const getWalletAddress = () => {
+    if (transaction.description?.includes("wallet")) {
+      return transaction.description.split(":")[1]?.trim() || transaction.description;
+    }
+    return transaction.reference || "N/A";
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm animate-in fade-in duration-200">
+      <div
+        ref={modalRef}
+        className="fixed inset-0 z-50 flex items-center justify-center p-4"
+        onClick={onClose}
+      >
+        <div
+          className="bg-card text-card-foreground rounded-xl p-6 shadow-2xl border border-border/50 w-full max-w-md md:max-w-2xl max-h-[90vh] overflow-y-auto"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="flex items-center justify-between mb-6">
+            <h2 className="text-2xl font-bold">Transaction Details</h2>
+            <button
+              onClick={onClose}
+              className="p-2 rounded-lg hover:bg-muted transition-colors focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2"
+              aria-label="Close modal"
+            >
+              <X className="h-5 w-5 text-muted-foreground" />
+            </button>
+          </div>
+
+          <div className="space-y-6">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-muted-foreground">Transaction ID</p>
+                <div className="flex items-center gap-2">
+                  <p className="font-mono text-sm break-all">
+                    {transaction.reference || transaction.id}
+                  </p>
+                  <button
+                    onClick={() => handleCopy(transaction.reference || transaction.id, 'txId')}
+                    className="p-1 rounded hover:bg-muted transition-colors focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-1"
+                    aria-label="Copy transaction ID"
+                  >
+                    {copiedTxId ? (
+                      <Check className="h-4 w-4 text-green-600" />
+                    ) : (
+                      <Copy className="h-4 w-4 text-muted-foreground" />
+                    )}
+                  </button>
+                </div>
+              </div>
+
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-muted-foreground">Type</p>
+                <span
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium border",
+                    getTypeColor(transaction.type)
+                  )}
+                >
+                  {getTypeIcon(transaction.type)}
+                  {transaction.type}
+                </span>
+              </div>
+
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-muted-foreground">Status</p>
+                <span
+                  className={cn(
+                    "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-xs font-medium border",
+                    getStatusColor(transaction.status)
+                  )}
+                >
+                  {getStatusIcon(transaction.status)}
+                  {transaction.status}
+                </span>
+              </div>
+
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-muted-foreground">Date & Time</p>
+                <p className="text-sm">
+                  {transaction.date}
+                </p>
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-muted-foreground">Amount</p>
+                <p className={cn(
+                  "text-2xl font-bold",
+                  transaction.type === "Deposit" ? "text-green-600" : "text-foreground"
+                )}
+                >
+                  <span className="mr-1">
+                    {transaction.type === "Deposit" ? "+" : transaction.type === "Withdraw" ? "-" : ""}
+                  </span>
+                  {transaction.amount.toLocaleString()} {transaction.currency}
+                </p>
+                {transaction.type === "Convert" && transaction.toAmount != null && transaction.toCurrency && (
+                  <div className="mt-2 p-3 bg-muted/30 rounded-lg">
+                    <p className="text-xs text-muted-foreground mb-1">You received</p>
+                    <p className="text-lg font-semibold">
+                      {transaction.toAmount.toLocaleString()} {transaction.toCurrency}
+                    </p>
+                  </div>
+                )}
+              </div>
+
+              {transaction.type === "Convert" && transaction.exchangeRate != null && (
+                <div className="space-y-2">
+                  <p className="text-sm font-medium text-muted-foreground">Exchange Rate</p>
+                  <p className="text-sm">
+                    1 {transaction.toCurrency} = {transaction.exchangeRate.toLocaleString()} {transaction.currency}
+                  </p>
+                </div>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-muted-foreground">Wallet Address</p>
+              <div className="flex items-center gap-2">
+                <p className="font-mono text-sm break-all">
+                  {getWalletAddress()}
+                </p>
+                <button
+                  onClick={() => handleCopy(getWalletAddress(), 'address')}
+                  className="p-1 rounded hover:bg-muted transition-colors focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-1"
+                  aria-label="Copy wallet address"
+                >
+                  {copied ? (
+                    <Check className="h-4 w-4 text-green-600" />
+                  ) : (
+                    <Copy className="h-4 w-4 text-muted-foreground" />
+                  )}
+                </button>
+              </div>
+            </div>
+
+            {transaction.fee != null && (
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-muted-foreground">Fee</p>
+                <p className="text-sm">
+                  {transaction.fee.toLocaleString()} {transaction.currency}
+                </p>
+              </div>
+            )}
+
+            {transaction.description && (
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-muted-foreground">Description</p>
+                <p className="text-sm text-muted-foreground">
+                  {transaction.description}
+                </p>
+              </div>
+            )}
+          </div>
+
+          <div className="mt-8 flex justify-end">
+            <button
+              onClick={onClose}
+              className="px-6 py-2.5 bg-muted hover:bg-muted/80 text-foreground font-medium rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-2"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/transaction-table.tsx
+++ b/components/dashboard/transaction-table.tsx
@@ -6,9 +6,10 @@ import { Transaction } from "@/lib/api/transactions";
 
 interface TransactionTableProps {
   transactions: Transaction[];
+  onTransactionClick?: (transaction: Transaction) => void;
 }
 
-export function TransactionTable({ transactions }: TransactionTableProps) {
+export function TransactionTable({ transactions, onTransactionClick }: TransactionTableProps) {
   return (
     <div className="rounded-md border bg-card text-card-foreground shadow-sm overflow-x-auto">
       <table className="w-full min-w-[600px] text-left">
@@ -23,7 +24,11 @@ export function TransactionTable({ transactions }: TransactionTableProps) {
         </thead>
         <tbody className="divide-y border-border">
           {transactions.map((tx) => (
-            <tr key={tx.id} className="hover:bg-muted/50 transition-colors">
+            <tr 
+              key={tx.id} 
+              className="hover:bg-muted/50 transition-colors cursor-pointer"
+              onClick={() => onTransactionClick?.(tx)}
+            >
               <td className="px-6 py-4">
                 <div className="flex items-center gap-3">
                   <div

--- a/lib/utils/format.ts
+++ b/lib/utils/format.ts
@@ -6,3 +6,16 @@ export function formatCurrency(amount: number, currency: string): string {
     currency: upperCurrency,
   }).format(amount);
 }
+
+export function formatDateTime(isoString: string): string {
+  const date = new Date(isoString);
+  return date.toLocaleString('en-US', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    hour12: true,
+    timeZoneName: 'short',
+  });
+}

--- a/lib/utils/index.ts
+++ b/lib/utils/index.ts
@@ -1,6 +1,9 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
+import { formatDateTime } from './format';
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export { formatDateTime };


### PR DESCRIPTION

## Summary

Builds a transaction detail modal that opens when clicking any row in the transaction history table. Shows full transaction details including type, amount, status, date, transaction ID, and exchange rate for Convert transactions.

## Changes

- **components/dashboard/transaction-detail-modal.tsx** — New modal component displaying:
  - Transaction ID with copy button
  - Type badge (Deposit / Withdraw / Convert)
  - Status badge with icon (Success / Failed / Pending)
  - Amount and currency
  - For Convert: fromAmount → toAmount with exchange rate
  - Date and time (formatted)
  - Wallet address
  - Closes on ESC key and backdrop click

- **components/dashboard/transaction-table.tsx** — Made each row clickable with  prop

- **components/dashboard/recent-transactions.tsx** — Integrated modal state management; desktop table and mobile list rows both trigger the modal

- **lib/utils/date.ts** — Added  utility for consistent date formatting

## Backend

Confirmed GET /transactions/:id endpoint exists in lib/api/transactions.ts:137.

Closes #252
