### PR TITLE
feat: spending insights page with trend chart and sidebar nav

### DIFF
--- a/app/(dashboard)/insights/page.tsx
+++ b/app/(dashboard)/insights/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getTransactions, Transaction } from "@/lib/api/transactions";
+import { calculateInsights, SpendingInsights } from "@/lib/utils/insights";
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { TrendingUp, ArrowUpDown, ArrowDownLeft, ArrowUpRight, Calendar } from "lucide-react";
+
+function StatCard({
+  label,
+  value,
+  icon: Icon,
+}: {
+  label: string;
+  value: string;
+  icon: React.ElementType;
+}) {
+  return (
+    <div className="bg-card border border-border/50 rounded-xl p-4 flex items-center gap-4 shadow-sm">
+      <div className="bg-primary/10 rounded-full p-2">
+        <Icon className="h-5 w-5 text-primary" />
+      </div>
+      <div>
+        <p className="text-xs text-muted-foreground">{label}</p>
+        <p className="text-base font-semibold">{value}</p>
+      </div>
+    </div>
+  );
+}
+
+function fmt(n: number) {
+  return n.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+export default function InsightsPage() {
+  const [insights, setInsights] = useState<SpendingInsights | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        // Fetch all transactions (large limit) for full insight accuracy
+        const result = await getTransactions({ page: 1, limit: 1000 });
+        if (cancelled) return;
+        if (result.data.length === 0) {
+          setInsights(null);
+        } else {
+          setInsights(calculateInsights(result.data));
+        }
+      } catch (e) {
+        if (!cancelled) setError(e instanceof Error ? e.message : "Failed to load insights");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-sm text-muted-foreground">{error}</p>
+      </div>
+    );
+  }
+
+  if (!insights) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 gap-2 text-center">
+        <TrendingUp className="h-12 w-12 text-muted-foreground/50" />
+        <p className="text-base font-medium">No insights yet</p>
+        <p className="text-sm text-muted-foreground">
+          Make your first transaction to see your spending patterns.
+        </p>
+      </div>
+    );
+  }
+
+  const { biggestTransaction } = insights;
+
+  return (
+    <div className="flex flex-col gap-6 max-w-5xl mx-auto w-full">
+      <h1 className="text-xl font-semibold">Spending Insights</h1>
+
+      {/* This month summary */}
+      <section>
+        <h2 className="text-sm font-medium text-muted-foreground mb-3">This Month</h2>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <StatCard label="Total Converted" value={fmt(insights.totalConvertedThisMonth)} icon={ArrowUpDown} />
+          <StatCard label="Total Withdrawn" value={fmt(insights.totalWithdrawnThisMonth)} icon={ArrowUpRight} />
+          <StatCard label="Total Deposited" value={fmt(insights.totalDepositedThisMonth)} icon={ArrowDownLeft} />
+        </div>
+      </section>
+
+      {/* Highlights row */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+        <div className="bg-card border border-border/50 rounded-xl p-4 shadow-sm">
+          <p className="text-xs text-muted-foreground mb-1">Top Currency Pair</p>
+          <p className="text-sm font-semibold">
+            You convert <span className="text-primary">{insights.mostUsedPair}</span> most often
+          </p>
+        </div>
+        <div className="bg-card border border-border/50 rounded-xl p-4 shadow-sm">
+          <p className="text-xs text-muted-foreground mb-1">Average Transaction</p>
+          <p className="text-sm font-semibold">{fmt(insights.averageTransactionAmount)}</p>
+        </div>
+        <div className="bg-card border border-border/50 rounded-xl p-4 shadow-sm">
+          <p className="text-xs text-muted-foreground mb-1">Most Active Day</p>
+          <div className="flex items-center gap-2">
+            <Calendar className="h-4 w-4 text-primary" />
+            <p className="text-sm font-semibold">{insights.mostActiveDay}</p>
+          </div>
+        </div>
+        <div className="bg-card border border-border/50 rounded-xl p-4 shadow-sm">
+          <p className="text-xs text-muted-foreground mb-1">Biggest Transaction</p>
+          <p className="text-sm font-semibold">
+            {fmt(biggestTransaction.amount)} {biggestTransaction.currency}
+          </p>
+          <p className="text-xs text-muted-foreground mt-0.5">{biggestTransaction.type} · {biggestTransaction.date}</p>
+        </div>
+      </div>
+
+      {/* Monthly trend chart */}
+      <section>
+        <h2 className="text-sm font-medium text-muted-foreground mb-3">6-Month Trend</h2>
+        <div className="bg-card border border-border/50 rounded-xl p-4 shadow-sm">
+          <ResponsiveContainer width="100%" height={260}>
+            <LineChart data={insights.monthlyTrend} margin={{ top: 5, right: 10, left: 0, bottom: 5 }}>
+              <XAxis dataKey="month" tick={{ fontSize: 11 }} />
+              <YAxis tick={{ fontSize: 11 }} width={60} />
+              <Tooltip formatter={(v) => fmt(Number(v))} />
+              <Legend />
+              <Line type="monotone" dataKey="converted" stroke="#EAB308" strokeWidth={2} dot={false} name="Converted" />
+              <Line type="monotone" dataKey="withdrawn" stroke="#EF4444" strokeWidth={2} dot={false} name="Withdrawn" />
+              <Line type="monotone" dataKey="deposited" stroke="#22C55E" strokeWidth={2} dot={false} name="Deposited" />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/components/dashboard/sidebar.tsx
+++ b/components/dashboard/sidebar.tsx
@@ -8,6 +8,8 @@ import {
   CircleUserRound,
   ChevronLeft,
   ChevronRight,
+  ArrowUpDown,
+  TrendingUp,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useSidebarStore } from "@/hooks/use-sidebar-store";
@@ -17,6 +19,7 @@ const menuItems = [
   { icon: Home, label: "Dashboard", href: "/dashboard" },
   // { icon: ArrowUpDown, label: "Convert", href: "/convert" },
   { icon: Mail, label: "Transactions", href: "/transactions" },
+  { icon: TrendingUp, label: "Insights", href: "/insights" },
   { icon: CircleUserRound, label: "Settings", href: "/settings" },
 ];
 

--- a/lib/utils/insights.ts
+++ b/lib/utils/insights.ts
@@ -1,0 +1,97 @@
+import { Transaction } from "@/lib/api/transactions";
+
+export interface MonthlyTotal {
+  month: string;
+  converted: number;
+  withdrawn: number;
+  deposited: number;
+}
+
+export interface SpendingInsights {
+  totalConvertedThisMonth: number;
+  totalWithdrawnThisMonth: number;
+  totalDepositedThisMonth: number;
+  mostUsedPair: string;
+  biggestTransaction: Transaction;
+  averageTransactionAmount: number;
+  monthlyTrend: MonthlyTotal[];
+  mostActiveDay: string;
+}
+
+const DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+export function calculateInsights(transactions: Transaction[]): SpendingInsights {
+  const now = new Date();
+  const thisMonth = now.getMonth();
+  const thisYear = now.getFullYear();
+
+  let totalConvertedThisMonth = 0;
+  let totalWithdrawnThisMonth = 0;
+  let totalDepositedThisMonth = 0;
+  const pairCount: Record<string, number> = {};
+  const dayCounts: number[] = Array(7).fill(0);
+
+  for (const tx of transactions) {
+    const d = new Date(tx.date);
+    const isThisMonth = d.getMonth() === thisMonth && d.getFullYear() === thisYear;
+
+    if (isThisMonth) {
+      if (tx.type === "Convert") totalConvertedThisMonth += tx.amount;
+      else if (tx.type === "Withdraw") totalWithdrawnThisMonth += tx.amount;
+      else if (tx.type === "Deposit") totalDepositedThisMonth += tx.amount;
+    }
+
+    if (tx.type === "Convert" && tx.toCurrency) {
+      const pair = `${tx.currency} → ${tx.toCurrency}`;
+      pairCount[pair] = (pairCount[pair] ?? 0) + 1;
+    }
+
+    dayCounts[d.getDay()]++;
+  }
+
+  const mostUsedPair =
+    Object.entries(pairCount).sort((a, b) => b[1] - a[1])[0]?.[0] ?? "—";
+
+  const biggestTransaction = transactions.reduce(
+    (max, tx) => (tx.amount > max.amount ? tx : max),
+    transactions[0]
+  );
+
+  const averageTransactionAmount =
+    transactions.reduce((sum, tx) => sum + tx.amount, 0) / transactions.length;
+
+  const mostActiveDay = DAYS[dayCounts.indexOf(Math.max(...dayCounts))];
+
+  // Build last 6 months trend
+  const monthlyTrend: MonthlyTotal[] = Array.from({ length: 6 }, (_, i) => {
+    const d = new Date(thisYear, thisMonth - (5 - i), 1);
+    return {
+      month: d.toLocaleString("en-US", { month: "short", year: "numeric" }),
+      converted: 0,
+      withdrawn: 0,
+      deposited: 0,
+    };
+  });
+
+  for (const tx of transactions) {
+    const d = new Date(tx.date);
+    const idx = monthlyTrend.findIndex(
+      (m) => m.month === d.toLocaleString("en-US", { month: "short", year: "numeric" })
+    );
+    if (idx === -1) continue;
+    if (tx.type === "Convert") monthlyTrend[idx].converted += tx.amount;
+    else if (tx.type === "Withdraw") monthlyTrend[idx].withdrawn += tx.amount;
+    else if (tx.type === "Deposit") monthlyTrend[idx].deposited += tx.amount;
+  }
+
+  return {
+    totalConvertedThisMonth,
+    totalWithdrawnThisMonth,
+    totalDepositedThisMonth,
+    mostUsedPair,
+    biggestTransaction,
+    averageTransactionAmount,
+    monthlyTrend,
+    mostActiveDay,
+  };
+}


### PR DESCRIPTION
Closes #351

Adds `/insights` dashboard page deriving all data from `GET /transactions`:

- **This month summary** — converted, withdrawn, deposited stat cards
- **Highlights** — top currency pair, average transaction, most active day, biggest transaction
- **6-month trend chart** — recharts `LineChart` (converted / withdrawn / deposited)
- **Empty state** — shown when user has no transactions
- **Sidebar** — Insights nav item added below Transactions

New files: `lib/utils/insights.ts` (pure `calculateInsights` utility), `app/(dashboard)/insights/page.tsx`