### PR TITLE
Implement consistent loading skeletons across data-fetching pages.

### DIFF
--- a/app/(admin)/admin/analytics/page.tsx
+++ b/app/(admin)/admin/analytics/page.tsx
@@ -7,6 +7,7 @@ import { AdminMetricCard } from "@/components/admin/AdminMetricCard";
 import { RevenueChart } from "@/components/admin/RevenueChart";
 import { getAdminMetrics, getAdminUsers, AdminMetrics, AdminUser } from "@/lib/api/admin";
 import { getRequestErrorMessage, isOfflineError } from "@/lib/api-client";
+import { AdminMetricCardsSkeleton } from "@/components/shared/page-skeletons";
 
 export default function AnalyticsPage() {
   const [metrics, setMetrics] = useState<AdminMetrics | null>(null);
@@ -50,12 +51,7 @@ export default function AnalyticsPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[400px] gap-2">
-        <Loader2 className="w-8 h-8 animate-spin text-gray-500" />
-        <p className="text-sm text-gray-500">Loading analytics...</p>
-      </div>
-    );
+    return <AdminMetricCardsSkeleton />;
   }
 
   if (error || !metrics) {

--- a/app/(admin)/admin/push-notifications/page.tsx
+++ b/app/(admin)/admin/push-notifications/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/api/admin";
 import { getRequestErrorMessage, isOfflineError } from "@/lib/api-client";
 import { Search, Plus } from "lucide-react";
+import { PushNotificationListSkeleton } from "@/components/shared/page-skeletons";
 
 export default function PushNotificationsPage() {
   const [notifications, setNotifications] = useState<PushNotification[]>([]);
@@ -88,8 +89,8 @@ export default function PushNotificationsPage() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-yellow-400" />
+      <div className="md:p-6 space-y-6">
+        <PushNotificationListSkeleton rows={5} />
       </div>
     );
   }

--- a/app/(admin)/admin/transactions/page.tsx
+++ b/app/(admin)/admin/transactions/page.tsx
@@ -7,6 +7,7 @@ import { TableTransaction } from "@/components/admin/transaction/TableTransactio
 import { TransactionFilters } from "@/components/admin/transaction/TransactionFilters";
 import { getAdminTransactions, AdminTransaction } from "@/lib/api/admin";
 import { EmptyState } from "@/components/shared/empty-state";
+import { AdminTableRowSkeleton } from "@/components/shared/page-skeletons";
 
 const ITEMS_PER_PAGE = 10;
 
@@ -96,9 +97,7 @@ export default function TransactionPage() {
           </button>
         </div>
       ) : loading ? (
-        <div className="flex justify-center items-center py-20 bg-white rounded-2xl border border-gray-100">
-          <Loader2 className="w-8 h-8 animate-spin text-gray-500" />
-        </div>
+        <AdminTableRowSkeleton rows={5} columns={6} />
       ) : transactions.length === 0 && (searchQuery || activeFilter !== "All") ? (
         <EmptyState
           icon={<ListFilter className="h-16 w-16" />}

--- a/app/(admin)/admin/users/page.tsx
+++ b/app/(admin)/admin/users/page.tsx
@@ -8,6 +8,7 @@ import { AdminUserTable } from '@/components/admin/AdminUserTable';
 import { BulkActionBar } from '@/components/admin/bulk-action-bar';
 import { UserDetailPanel } from '@/components/admin/UserDetailPanel';
 import { EmptyState } from '@/components/shared/empty-state';
+import { AdminTableRowSkeleton } from '@/components/shared/page-skeletons';
 
 const ITEMS_PER_PAGE = 10;
 
@@ -212,9 +213,7 @@ export default function UsersPage() {
           </button>
         </div>
       ) : loading ? (
-        <div className="flex justify-center items-center py-20">
-          <Loader2 className="w-8 h-8 animate-spin text-gray-500" />
-        </div>
+        <AdminTableRowSkeleton rows={5} columns={5} />
       ) : (
         <>
           {/* Desktop Table */}

--- a/app/(admin)/loading.tsx
+++ b/app/(admin)/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoader } from "@/components/shared/page-loader";
+
+export default function AdminLoading() {
+  return <PageLoader />;
+}

--- a/app/(dashboard)/loading.tsx
+++ b/app/(dashboard)/loading.tsx
@@ -1,0 +1,5 @@
+import { PageLoader } from "@/components/shared/page-loader";
+
+export default function DashboardLoading() {
+  return <PageLoader />;
+}

--- a/app/(dashboard)/notifications/page.tsx
+++ b/app/(dashboard)/notifications/page.tsx
@@ -5,18 +5,10 @@ import { Bell } from "lucide-react";
 import { useNotificationsStore } from "@/hooks/use-notifications-store";
 import { SwipeableNotificationItem } from "@/components/notifications";
 import { EmptyState } from "@/components/shared/empty-state";
+import { NotificationListSkeleton } from "@/components/shared/page-skeletons";
 
 function NotificationSkeleton() {
-  return (
-    <div className="flex items-start gap-3 p-4 animate-pulse">
-      <div className="h-9 w-9 rounded-full bg-muted shrink-0" />
-      <div className="flex-1 space-y-2">
-        <div className="h-3.5 w-1/3 rounded bg-muted" />
-        <div className="h-3 w-2/3 rounded bg-muted" />
-        <div className="h-3 w-1/4 rounded bg-muted" />
-      </div>
-    </div>
-  );
+  return <NotificationListSkeleton rows={5} />;
 }
 
 export default function NotificationsPage() {

--- a/app/(dashboard)/transactions/page.tsx
+++ b/app/(dashboard)/transactions/page.tsx
@@ -9,6 +9,7 @@ import { TransactionPagination } from "@/components/transactions/pagination";
 import { TransactionEmptyState } from "@/components/transactions/empty-state";
 import { TransactionDetails } from "@/components/transactions/transaction-details";
 import { exportTransactionsToCSV, generateCSVFilename } from "@/app/lib/utils/csv-export";
+import { TransactionTableSkeleton } from "@/components/shared/page-skeletons";
 
 const ITEMS_PER_PAGE = 10;
 
@@ -133,9 +134,7 @@ useEffect(() => {
                 />
 
                 {isLoading ? (
-                    <div className="flex items-center justify-center py-20">
-                        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-                    </div>
+                    <TransactionTableSkeleton rows={5} />
                 ) : error ? (
                     <div className="flex flex-col items-center justify-center py-20 gap-3">
                         <p className="text-sm text-muted-foreground">{error}</p>

--- a/app/dashboard/transactions/page.tsx
+++ b/app/dashboard/transactions/page.tsx
@@ -14,6 +14,7 @@ import {
   generateCSVFilename,
 } from "@/app/lib/utils/csv-export";
 import { PullToRefresh } from "@/components/shared/pull-to-refresh";
+import { TransactionTableSkeleton } from "@/components/shared/page-skeletons";
 
 const ITEMS_PER_PAGE = 10;
 
@@ -184,9 +185,7 @@ function TransactionsContent() {
           />
 
           {isLoading ? (
-            <div className="flex items-center justify-center py-20">
-              <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
-            </div>
+            <TransactionTableSkeleton rows={5} />
           ) : error ? (
             <div className="flex flex-col items-center justify-center py-20 gap-3">
               <p className="text-sm text-muted-foreground">{error}</p>

--- a/components/dashboard/account-overview.tsx
+++ b/components/dashboard/account-overview.tsx
@@ -9,6 +9,7 @@ import {
   CircleDollarSign,
 } from "lucide-react";
 import { Tooltip } from "@/components/ui/tooltip";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useEffect, useState } from "react";
 import { getBalances } from "@/lib/api/wallet";
 import { getProfile } from "@/lib/api/users";
@@ -148,9 +149,9 @@ export function AccountOverview({
             {/* Balance row */}
             <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
               {isLoading ? (
-                <div className="space-y-2.5 animate-pulse">
-                  <div className="h-4 w-24 bg-muted rounded" />
-                  <div className="h-9 w-44 bg-muted rounded" />
+                <div className="space-y-2.5">
+                  <Skeleton className="h-4 w-24" />
+                  <Skeleton className="h-9 w-44" />
                 </div>
               ) : error ? (
                 <p className="text-sm text-red-500">{error}</p>
@@ -167,7 +168,7 @@ export function AccountOverview({
 
               {/* Wallet address pill — desktop only */}
               {isLoading ? (
-                <div className="hidden md:block h-9 w-36 bg-muted rounded animate-pulse" />
+                <Skeleton className="hidden md:block h-9 w-36" />
               ) : !error ? (
                 <div className="hidden md:inline-flex md:items-center gap-2 bg-muted rounded-sm border border-border px-4 py-2">
                   <Tooltip content={`Stellar wallet: ${walletAddress}`}>
@@ -211,9 +212,9 @@ export function AccountOverview({
 
             {/* Mini balance cards */}
             {isLoading ? (
-              <div className="grid w-full grid-cols-1 md:grid-cols-2 gap-4 animate-pulse">
-                <div className="rounded-sm bg-muted h-20 md:border-[0.43px] border-[#79797966]" />
-                <div className="rounded-sm bg-muted h-20 md:border-[0.43px] border-[#79797966]" />
+              <div className="grid w-full grid-cols-1 md:grid-cols-2 gap-4">
+                <Skeleton className="h-20 rounded-sm" />
+                <Skeleton className="h-20 rounded-sm" />
               </div>
             ) : !error ? (
               <div className="grid w-full grid-cols-1 md:grid-cols-2 gap-4">

--- a/components/dashboard/convert/convert-form.tsx
+++ b/components/dashboard/convert/convert-form.tsx
@@ -6,6 +6,8 @@ import { cn } from "@/lib/utils";
 import { getBalances } from "@/lib/api/wallet";
 import { createSwap } from "@/lib/api/transactions";
 import { getRequestErrorMessage } from "@/lib/api-client";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ConvertFormSkeleton } from "@/components/shared/page-skeletons";
 import { EmptyState } from "@/components/shared/empty-state";
 
 interface CurrencyOption {
@@ -32,6 +34,7 @@ export function ConvertForm() {
   const [errors, setErrors] = useState<{ amount?: string }>({});
 
   const [balances, setBalances] = useState<Record<string, string>>({});
+  const [isLoadingBalances, setIsLoadingBalances] = useState(true);
   const [exchangeRate, setExchangeRate] = useState<number>(0);
   const [isLoadingRate, setIsLoadingRate] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -45,6 +48,7 @@ export function ConvertForm() {
     CURRENCIES.find((c) => c.id === toCurrency) || CURRENCIES[1];
 
   useEffect(() => {
+    setIsLoadingBalances(true);
     getBalances()
       .then((res) => {
         const newBalances: Record<string, string> = {};
@@ -60,7 +64,8 @@ export function ConvertForm() {
             fallback: "Unable to load balances. Please try again.",
           }),
         });
-      });
+      })
+      .finally(() => setIsLoadingBalances(false));
   }, []);
 
     useEffect(() => {
@@ -208,6 +213,10 @@ export function ConvertForm() {
     !!rateError ||
     isLoadingRate ||
     isSubmitting;
+
+  if (isLoadingBalances) {
+    return <ConvertFormSkeleton />;
+  }
 
   return (
     <div className="w-full max-w-md mx-auto px-4 py-6">
@@ -465,11 +474,9 @@ export function ConvertForm() {
         {/* Rate Preview */}
         <div className="space-y-2">
           {isLoadingRate ? (
-            <div className="flex items-center justify-center px-4 py-3 rounded-lg bg-muted/30 border border-border/50">
-              <Loader2 className="h-4 w-4 animate-spin text-muted-foreground mr-2" />
-              <span className="text-sm text-muted-foreground">
-                Fetching live rates...
-              </span>
+            <div className="px-4 py-3 rounded-lg bg-muted/30 border border-border/50 space-y-2">
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="h-4 w-40" />
             </div>
           ) : rateError ? (
             <EmptyState

--- a/components/dashboard/deposit/wallet-address-card.tsx
+++ b/components/dashboard/deposit/wallet-address-card.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from "react";
 import { QRCodeSVG } from "qrcode.react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { DepositWalletSkeleton } from "@/components/shared/page-skeletons";
 import { ApiErrorState } from "@/components/shared/api-error-state";
 import { haptics } from "@/lib/utils/haptics";
 
@@ -71,17 +73,8 @@ export function WalletAddressCard({
     setTimeout(() => setCopied(false), 2000);
   };
 
-  // Loading skeleton
   if (isLoading) {
-    return (
-      <div className="rounded-xl border border-zinc-200 bg-white p-6 dark:border-zinc-800 dark:bg-zinc-900">
-        <div className="flex flex-col items-center gap-4 animate-pulse">
-          <div className="h-40 w-40 rounded-lg bg-zinc-200 dark:bg-zinc-700" />
-          <div className="h-5 w-3/4 rounded bg-zinc-200 dark:bg-zinc-700" />
-          <div className="h-4 w-1/2 rounded bg-zinc-200 dark:bg-zinc-700" />
-        </div>
-      </div>
-    );
+    return <DepositWalletSkeleton />;
   }
 
   // Error state

--- a/components/dashboard/recent-transactions.tsx
+++ b/components/dashboard/recent-transactions.tsx
@@ -15,6 +15,7 @@ import { Transaction, getTransactions } from "@/lib/api/transactions";
 import { TransactionEmptyState } from "@/components/transactions/empty-state";
 import { getRequestErrorMessage, isOfflineError } from "@/lib/api-client";
 import { TransactionDetailModal } from "./transaction-detail-modal";
+import { TransactionTableSkeleton } from "@/components/shared/page-skeletons";
 import { useWebSocket } from "@/hooks/use-websocket";
 import { useAuthStore } from "@/hooks/use-auth-store";
 export function RecentTransactions() {
@@ -105,21 +106,7 @@ export function RecentTransactions() {
           </div>
         )}
         {state.status === "loading" ? (
-          /* Skeleton rows — matches the shape of real transaction rows */
-          <div className="space-y-3 p-4 animate-pulse">
-            {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <div className="h-10 w-10 rounded-full bg-muted" />
-                  <div className="space-y-1.5">
-                    <div className="h-3 w-24 bg-muted rounded" />
-                    <div className="h-3 w-16 bg-muted rounded" />
-                  </div>
-                </div>
-                <div className="h-3 w-16 bg-muted rounded" />
-              </div>
-            ))}
-          </div>
+          <TransactionTableSkeleton rows={5} />
         ) : state.status === "error" ? (
           <div className="flex flex-col items-center justify-center py-10 gap-3">
             <p className="text-sm text-red-500">{state.message}</p>

--- a/components/notifications/notifications-panel.tsx
+++ b/components/notifications/notifications-panel.tsx
@@ -7,21 +7,10 @@ import { useNotificationsStore } from "@/hooks/use-notifications-store";
 import { NotificationItem } from "./notification-item";
 import { Checkbox } from "@/components/ui/checkbox";
 import { EmptyState } from "@/components/shared/empty-state";
+import { NotificationListSkeleton } from "@/components/shared/page-skeletons";
 
 function PanelSkeleton() {
-  return (
-    <div className="divide-y divide-border">
-      {Array.from({ length: 4 }).map((_, i) => (
-        <div key={i} className="flex items-start gap-3 p-4 animate-pulse">
-          <div className="h-9 w-9 rounded-full bg-muted shrink-0" />
-          <div className="flex-1 space-y-2">
-            <div className="h-3.5 w-1/3 rounded bg-muted" />
-            <div className="h-3 w-2/3 rounded bg-muted" />
-          </div>
-        </div>
-      ))}
-    </div>
-  );
+  return <NotificationListSkeleton rows={4} />;
 }
 
 export function NotificationsPanel() {

--- a/components/settings/profile-tab.tsx
+++ b/components/settings/profile-tab.tsx
@@ -5,6 +5,7 @@ import { useEffect, useRef, useState } from "react";
 import { getProfile, updateProfile, type UpdateProfileDto, type UserProfile } from "@/lib/api/users";
 import { useAuthStore } from "@/hooks/use-auth-store";
 import { toast } from "@/hooks/use-toast-store";
+import { SettingsProfileSkeleton } from "@/components/shared/page-skeletons";
 
 export function ProfileTab() {
   const setAuth = useAuthStore((s) => s.setAuth);
@@ -114,12 +115,7 @@ export function ProfileTab() {
   };
 
   if (isFetching) {
-    return (
-      <div className="flex items-center justify-center py-16 text-muted-foreground">
-        <Loader2 className="size-6 animate-spin mr-2" aria-hidden="true" />
-        <span>Loading profile…</span>
-      </div>
-    );
+    return <SettingsProfileSkeleton />;
   }
 
   return (

--- a/components/shared/page-loader.tsx
+++ b/components/shared/page-loader.tsx
@@ -1,0 +1,11 @@
+export function PageLoader() {
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center">
+      <div
+        className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent"
+        role="status"
+        aria-label="Loading"
+      />
+    </div>
+  );
+}

--- a/components/shared/page-skeletons.tsx
+++ b/components/shared/page-skeletons.tsx
@@ -1,0 +1,218 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export function AccountOverviewSkeleton() {
+  return (
+    <div className="space-y-5 md:space-y-10">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="space-y-2.5">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-9 w-44" />
+        </div>
+        <Skeleton className="hidden md:block h-9 w-36" />
+      </div>
+      <div className="grid w-full grid-cols-1 md:grid-cols-2 gap-4">
+        <Skeleton className="h-20 rounded-sm" />
+        <Skeleton className="h-20 rounded-sm" />
+      </div>
+    </div>
+  );
+}
+
+export function TransactionTableSkeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <div className="space-y-0">
+      <div className="hidden md:block">
+        <div className="border-b bg-muted/30 px-6 py-4 flex gap-6">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-3 w-16" />
+          ))}
+        </div>
+        <div className="divide-y">
+          {Array.from({ length: rows }).map((_, i) => (
+            <div key={i} className="flex items-center gap-6 px-6 py-4">
+              <Skeleton className="h-8 w-8 rounded-full shrink-0" />
+              <Skeleton className="h-4 w-20" />
+              <Skeleton className="h-4 w-16" />
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-5 w-14 rounded-full" />
+              <Skeleton className="h-4 w-20 ml-auto" />
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="md:hidden space-y-4 p-4">
+        {Array.from({ length: rows }).map((_, i) => (
+          <div key={i} className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <Skeleton className="h-12 w-12 rounded-xl" />
+              <div className="space-y-2">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-3 w-16" />
+              </div>
+            </div>
+            <Skeleton className="h-6 w-16 rounded-full" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ConvertFormSkeleton() {
+  return (
+    <div className="w-full max-w-md mx-auto px-4 py-6 space-y-6">
+      <div className="space-y-2">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-4 w-64" />
+      </div>
+      <div className="space-y-4 bg-card rounded-2xl p-6 border border-border">
+        <Skeleton className="h-4 w-12" />
+        <Skeleton className="h-14 w-full rounded-xl" />
+        <Skeleton className="h-4 w-16" />
+        <Skeleton className="h-14 w-full rounded-xl" />
+      </div>
+      <div className="flex justify-center">
+        <Skeleton className="h-11 w-11 rounded-full" />
+      </div>
+      <div className="space-y-4 bg-card rounded-2xl p-6 border border-border">
+        <Skeleton className="h-4 w-8" />
+        <Skeleton className="h-14 w-full rounded-xl" />
+        <Skeleton className="h-4 w-16" />
+        <Skeleton className="h-14 w-full rounded-xl" />
+      </div>
+      <Skeleton className="h-12 w-full rounded-lg" />
+      <Skeleton className="h-12 w-full rounded-xl" />
+    </div>
+  );
+}
+
+export function DepositWalletSkeleton() {
+  return (
+    <div className="rounded-xl border border-border bg-card p-6">
+      <div className="flex flex-col items-center gap-4">
+        <Skeleton className="h-40 w-40 rounded-lg" />
+        <Skeleton className="h-5 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+        <Skeleton className="h-10 w-full rounded-md" />
+      </div>
+    </div>
+  );
+}
+
+export function SettingsProfileSkeleton() {
+  return (
+    <div className="rounded-2xl border border-border bg-card p-6 md:p-8 space-y-6">
+      <div className="border-b border-border pb-4 space-y-2">
+        <Skeleton className="h-7 w-24" />
+        <Skeleton className="h-4 w-56" />
+      </div>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="space-y-2">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-11 w-full rounded-lg" />
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-3 pt-4">
+        <Skeleton className="h-12 flex-1 rounded-sm" />
+        <Skeleton className="h-12 flex-1 rounded-sm" />
+      </div>
+    </div>
+  );
+}
+
+export function AdminMetricCardsSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-7 w-28" />
+        <Skeleton className="h-8 w-32" />
+      </div>
+      <div className="flex flex-wrap gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="bg-white rounded-2xl border border-gray-200 px-6 py-5 flex items-center gap-4 flex-1 min-w-[200px]"
+          >
+            <Skeleton className="h-[25px] w-[25px] rounded" />
+            <div className="space-y-2 flex-1">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-8 w-16" />
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-4">
+        <Skeleton className="h-64 flex-1 rounded-2xl" />
+        <Skeleton className="h-64 w-[43%] rounded-2xl" />
+      </div>
+      <AdminTableRowSkeleton rows={5} columns={5} />
+    </div>
+  );
+}
+
+export function AdminTableRowSkeleton({
+  rows = 5,
+  columns = 4,
+}: {
+  rows?: number;
+  columns?: number;
+}) {
+  return (
+    <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden">
+      <div className="border-b border-gray-100 px-6 py-4 flex gap-4">
+        {Array.from({ length: columns }).map((_, i) => (
+          <Skeleton key={i} className="h-3 w-24" />
+        ))}
+      </div>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div
+          key={i}
+          className="border-b border-gray-50 last:border-0 px-6 py-4 flex gap-4 items-center"
+        >
+          <Skeleton className="h-2.5 w-2.5 rounded-full shrink-0" />
+          {Array.from({ length: columns - 1 }).map((_, j) => (
+            <Skeleton key={j} className="h-4 flex-1" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function PushNotificationListSkeleton({ rows = 5 }: { rows?: number }) {
+  return (
+    <div className="space-y-0 border border-gray-200 rounded-lg overflow-hidden">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-4 px-4 py-4 border-b border-gray-100 last:border-0"
+        >
+          <Skeleton className="h-4 w-4 rounded" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-1/3" />
+            <Skeleton className="h-3 w-2/3" />
+          </div>
+          <Skeleton className="h-5 w-16 rounded-full" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function NotificationListSkeleton({ rows = 4 }: { rows?: number }) {
+  return (
+    <div className="divide-y divide-border">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="flex items-start gap-3 p-4">
+          <Skeleton variant="circle" className="h-9 w-9 shrink-0" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-3.5 w-1/3" />
+            <Skeleton className="h-3 w-2/3" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #203

Summary
Added components/shared/page-loader.tsx for full-page route transition spinners
Added components/shared/page-skeletons.tsx with reusable layout-matched skeletons
Added app/(dashboard)/loading.tsx and app/(admin)/loading.tsx
Replaced inline spinners with Skeleton-based placeholders on:
Dashboard account overview (balance cards)
Transactions pages (5 table rows)
Convert form (form fields while loading balances/rates)
Deposit wallet address card
Settings profile tab (profile fields)
Admin analytics (metric cards)
Admin users / transactions (table rows)
Admin push notifications (list items)
Notification panel and notifications page
Test plan

 Navigate between dashboard routes — route-level spinner shows during transitions

 Open /dashboard — balance card skeletons appear while data loads

 Open /dashboard/transactions — 5-row table skeleton instead of blank/spinner

 Open /dashboard/convert — form skeleton while balances load

 Open /dashboard/deposit — wallet card skeleton while address loads

 Open /dashboard/settings — profile field skeletons on Profile tab

 Open admin analytics, users, transactions, push-notifications — matching skeletons

 Open notification panel — list item skeletons while fetching

 Confirm no page shows skeleton + spinner at the same time

 npm run build and npm run lint pass
