### PR TITLE
[V2 200pts] Optimise images, fonts, and lazy loading to improve Core Web Vitals on landing page and dashboard

### DIFF
--- a/app/(admin)/admin/analytics/page.tsx
+++ b/app/(admin)/admin/analytics/page.tsx
@@ -3,10 +3,19 @@
 import { useState, useEffect, useRef } from "react";
 import { ChevronDown, UserPlus, ArrowUpDown, Clock, Coins, Loader2 } from "lucide-react";
 import { AdminMetricCard } from "@/components/admin/AdminMetricCard";
-import { RevenueChart } from "@/components/admin/RevenueChart";
-import { getAdminMetrics, getAdminUsers, AdminMetrics, AdminUser } from "@/lib/api/admin";
+import dynamic from "next/dynamic";
+import { getAdminMetrics, getAdminUsers, type AdminMetrics, type AdminUser } from "@/lib/api/admin";
 import { getRequestErrorMessage, isOfflineError } from "@/lib/api-client";
 import { AdminMetricCardsSkeleton } from "@/components/shared/page-skeletons";
+
+const RevenueChart = dynamic(() => import("@/components/admin/RevenueChart").then(mod => mod.RevenueChart), {
+  ssr: false,
+  loading: () => (
+    <div className="bg-white rounded-2xl flex-1 min-w-0 h-63.25 py-2.5 px-5 border border-gray-200 flex items-center justify-center">
+      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-yellow-400" />
+    </div>
+  ),
+});
 
 export default function AnalyticsPage() {
   const [metrics, setMetrics] = useState<AdminMetrics | null>(null);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,21 +17,25 @@ import { getMessages } from 'next-intl/server';
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
+  display: "swap",
 });
 
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+  display: "swap",
 });
 
 const inter = Inter({
   subsets: ["latin"],
   variable: "--font-inter",
+  display: "swap",
 });
 
 const manrope = Manrope({
   subsets: ["latin"],
   variable: "--font-manrope",
+  display: "swap",
 });
 
 export const metadata: Metadata = {

--- a/components/dashboard/InstantDepositModal.tsx
+++ b/components/dashboard/InstantDepositModal.tsx
@@ -1,15 +1,20 @@
 'use client';
 
-import React, { useRef } from 'react';
-import { X, ChevronRight } from 'lucide-react';
-import { QRCodeSVG } from 'qrcode.react';
-import { useFocusTrap } from '@/hooks/use-focus-trap';
-import { CopyButton } from '@/components/ui/copy-button';
 import React, { useState, useRef } from 'react';
 import { X, Copy, ChevronRight } from 'lucide-react';
-import { QRCodeSVG } from 'qrcode.react';
+import dynamic from 'next/dynamic';
 import { useFocusTrap } from '@/hooks/use-focus-trap';
+import { CopyButton } from '@/components/ui/copy-button';
 import { haptics } from '@/lib/utils/haptics';
+
+const QRCodeSVG = dynamic(() => import('qrcode.react').then(mod => mod.QRCodeSVG), {
+  ssr: false,
+  loading: () => (
+    <div className="w-38 h-38 md:w-58 md:h-58 bg-muted p-4 rounded-lg flex items-center justify-center text-center text-sm text-muted-foreground">
+      Loading QR code...
+    </div>
+  ),
+});
 
 type InstantDepositModalType = {
   onClose: () => void;
@@ -93,13 +98,6 @@ const InstantModalDeposit: React.FC<InstantDepositModalType> = ({
                 {walletAddress}
               </span>
               <CopyButton value={walletAddress} label='Copy wallet address' size='sm' />
-              <button
-                onClick={handleCopyAddress}
-                className='p-1 hover:bg-background rounded focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-offset-1'
-                aria-label='Copy wallet address'
-              >
-                <Copy className='w-4 h-4 text-muted-foreground' />
-              </button>
             </div>
           </div>
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -32,14 +32,16 @@ const securityHeaders = [
 const nextConfig: NextConfig = {
   poweredByHeader: false,
   images: {
-    domains: ["lh3.googleusercontent.com"],
     remotePatterns: [
       {
         protocol: "https",
         hostname: "lh3.googleusercontent.com",
       },
     ],
+    formats: ["image/avif", "image/webp"],
+    minimumCacheTTL: 60,
   },
+  compress: true,
   async redirects() {
     return [
       { source: "/sign-in", destination: "/login", permanent: true },


### PR DESCRIPTION
## Summary
This PR implements performance optimizations to improve Core Web Vitals (LCP, CLS, INP) on the landing page and dashboard. It is the rebased version of PR #393 (closed) targeting the v2 branch as requested.

## Changes Made
1. Self-host Fonts with `display: swap`
   - File: `app/layout.tsx`
   - Added `display: swap` to all font configurations (Geist, Geist_Mono, Inter, Manrope)
   - This ensures text is visible immediately with a fallback font while the custom font loads, improving LCP and reducing layout shifts.

2. Lazy Load Heavy Components with Dynamic Imports
   - File: `app/(admin)/admin/analytics/page.tsx`
   - Converted `RevenueChart` (recharts) to dynamic import with `ssr: false`
   - Added loading state with spinner for better UX
   - Reduces initial bundle size and improves initial page load time.
   - File: `components/dashboard/InstantDepositModal.tsx`
   - Converted `QRCodeSVG` (qrcode.react) to dynamic import with `ssr: false`
   - Added loading state for QR code component
   - QR code only loads when modal is opened, reducing initial bundle size.

3. Next.js Config Optimizations
   - File: `next.config.ts`
   - Removed deprecated `images.domains` in favour of `images.remotePatterns` (security improvement)
   - Added modern image formats: `["image/avif", "image/webp"]` for better compression
   - Set `minimumCacheTTL: 60` for image caching
   - Enabled `compress: true` for gzip compression
   - These optimizations reduce image payload sizes and improve LCP.

## Rebase Notes
This PR is the rebased version of PR #393 onto `v2`. The original PR commit (64da38a) was cherry-picked onto upstream `v2` (e5f7b07); conflicts in `app/layout.tsx`, `app/(admin)/admin/analytics/page.tsx`, and `next.config.ts` were resolved by preserving `v2`s structural additions while applying the PRs targeted Core Web Vitals optimizations. Duplicate imports in `components/dashboard/InstantDepositModal.tsx` and a redundant copy icon button were cleaned up during merge.

Closes #245
Replaces #393