### PR TITLE
feat: add withdrawal confirmation modal with full address display and…

### DIFF
--- a/components/dashboard/withdraw/index.ts
+++ b/components/dashboard/withdraw/index.ts
@@ -1,0 +1,2 @@
+export { WithdrawalConfirmationModal } from "./withdrawal-confirmation-modal";
+export { WithdrawalSuccess } from "./withdrawal-success";

--- a/components/dashboard/withdraw/withdrawal-confirmation-modal.tsx
+++ b/components/dashboard/withdraw/withdrawal-confirmation-modal.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface WithdrawalConfirmationModalProps {
+  amount: string;
+  currency: string;
+  destinationAddress: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isLoading: boolean;
+}
+
+export function WithdrawalConfirmationModal({
+  amount,
+  currency,
+  destinationAddress,
+  onConfirm,
+  onCancel,
+  isLoading,
+}: WithdrawalConfirmationModalProps) {
+  return (
+    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+        onClick={onCancel}
+        aria-hidden="true"
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirmation-modal-title"
+        className="relative w-full max-w-md bg-card rounded-xl shadow-2xl border border-border p-6 space-y-6 animate-in fade-in zoom-in-95 duration-200"
+      >
+        <h3
+          id="confirmation-modal-title"
+          className="text-lg font-bold text-foreground text-center"
+        >
+          Confirm Withdrawal
+        </h3>
+
+        <div className="bg-muted/30 rounded-xl p-5 space-y-4 border border-border">
+          <div className="text-center pb-4 border-b border-border">
+            <p className="text-sm text-muted-foreground mb-1">You are withdrawing</p>
+            <p className="text-2xl font-bold text-foreground">
+              {parseFloat(amount).toLocaleString()} {currency}
+            </p>
+          </div>
+          <div className="space-y-2">
+            <p className="text-sm text-muted-foreground">To:</p>
+            <p className="text-sm font-mono font-medium text-foreground break-all bg-muted/50 p-3 rounded-lg border border-border">
+              {destinationAddress}
+            </p>
+          </div>
+        </div>
+
+        <div className="bg-red-500/10 border border-red-500/30 rounded-lg p-3">
+          <p className="text-xs text-red-600 dark:text-red-400 text-center font-medium">
+            This action cannot be undone. Funds sent to an incorrect address cannot be recovered.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <button
+            onClick={onConfirm}
+            disabled={isLoading}
+            className={cn(
+              "w-full py-3.5 rounded-xl font-semibold",
+              "bg-primary text-primary-foreground",
+              "hover:bg-primary/90 active:scale-[0.98]",
+              "transition-all duration-200",
+              "flex items-center justify-center gap-2",
+              isLoading && "opacity-80 cursor-not-allowed"
+            )}
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className="size-5 animate-spin" />
+                Processing...
+              </>
+            ) : (
+              "Confirm Withdrawal"
+            )}
+          </button>
+          <button
+            onClick={onCancel}
+            disabled={isLoading}
+            className="w-full py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/withdraw/withdrawal-success.tsx
+++ b/components/dashboard/withdraw/withdrawal-success.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { CheckCircle2, ExternalLink, RefreshCw } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { useWithdrawalStore } from "@/hooks/useWithdrawalStore";
+import type { Transaction } from "@/lib/api/transactions";
+import { CopyButton } from "@/components/ui/copy-button";
+
+interface WithdrawalSuccessProps {
+  transaction: Transaction;
+}
+
+export function WithdrawalSuccess({ transaction }: WithdrawalSuccessProps) {
+  const router = useRouter();
+  const { close, reset } = useWithdrawalStore();
+
+  const handleViewTransactions = () => {
+    close();
+    setTimeout(() => reset(), 300);
+    router.push("/dashboard/transactions");
+  };
+
+  const handleNewWithdrawal = () => {
+    reset();
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <div className="flex flex-col items-center pt-8 pb-4">
+        <div className="w-20 h-20 rounded-full flex items-center justify-center mb-4 bg-green-500/10">
+          <CheckCircle2 className="size-10 text-green-500" />
+        </div>
+        <h2 className="text-xl font-bold text-green-500">Withdrawal Submitted</h2>
+        <p className="text-sm text-muted-foreground mt-1 text-center">
+          Your withdrawal has been submitted successfully
+        </p>
+      </div>
+
+      <div className="bg-muted/30 rounded-xl p-5 space-y-4 border border-border">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">Transaction ID</span>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-mono font-medium text-foreground">
+              {transaction.id}
+            </span>
+            <CopyButton value={transaction.id} label="Copy transaction ID" size="sm" />
+          </div>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">Amount</span>
+          <span className="text-sm font-medium text-foreground">
+            {transaction.amount.toLocaleString()} {transaction.currency}
+          </span>
+        </div>
+        {transaction.walletAddress && (
+          <div className="space-y-1">
+            <span className="text-sm text-muted-foreground">Destination Address</span>
+            <p className="text-sm font-mono font-medium text-foreground break-all bg-muted/50 p-2 rounded border border-border">
+              {transaction.walletAddress}
+            </p>
+          </div>
+        )}
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">Estimated Processing Time</span>
+          <span className="text-sm font-medium text-foreground">15-30 minutes</span>
+        </div>
+      </div>
+
+      <div className="bg-blue-500/10 border border-blue-500/20 rounded-lg p-3">
+        <p className="text-xs text-blue-600 dark:text-blue-400">
+          Your transaction is being processed. It may take a few minutes to reflect in your
+          wallet.
+        </p>
+      </div>
+
+      <div className="space-y-3 pt-2">
+        <button
+          onClick={handleViewTransactions}
+          className="w-full py-3.5 rounded-xl font-semibold bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all duration-200 flex items-center justify-center gap-2"
+        >
+          <ExternalLink className="size-4" />
+          View in Transactions
+        </button>
+        <button
+          onClick={handleNewWithdrawal}
+          className="w-full py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors flex items-center justify-center gap-2"
+        >
+          <RefreshCw className="size-4" />
+          Make Another Withdrawal
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard/withdrawal/WithdrawalModal.tsx
+++ b/components/dashboard/withdrawal/WithdrawalModal.tsx
@@ -6,12 +6,13 @@ import { useFocusTrap } from "@/hooks/use-focus-trap";
 import { WithdrawalMethodSelect } from "./WithdrawalMethodSelect";
 import { WithdrawalForm } from "./WithdrawalForm";
 import { WithdrawalReview } from "./WithdrawalReview";
-import { WithdrawalSuccess } from "./WithdrawalSuccess";
+import { WithdrawalSuccess } from "@/components/dashboard/withdraw/withdrawal-success";
+import type { Transaction } from "@/lib/api/transactions";
 import { cn } from "@/lib/utils";
-import { X } from "lucide-react";
+import { X, XCircle } from "lucide-react";
 
 export function WithdrawalModal() {
-  const { isOpen, step, close, reset } = useWithdrawalStore();
+  const { isOpen, step, close, reset, amount, currency, walletAddress, transactionId, errorMessage } = useWithdrawalStore();
   const isProcessing = step === "processing";
   const desktopModalRef = useRef<HTMLDivElement>(null);
   const mobileModalRef = useRef<HTMLDivElement>(null);
@@ -36,6 +37,18 @@ export function WithdrawalModal() {
     }
   };
 
+  const successTransaction: Transaction = {
+    id: transactionId ?? "",
+    type: "Withdraw",
+    currency,
+    amount: parseFloat(amount) || 0,
+    amountString: `${parseFloat(amount).toLocaleString()} ${currency}`,
+    date: new Date().toISOString(),
+    status: "Pending",
+    reference: transactionId ?? "",
+    walletAddress,
+  };
+
   const renderStep = () => {
     switch (step) {
       case "select":
@@ -46,12 +59,37 @@ export function WithdrawalModal() {
       case "processing":
         return <WithdrawalReview />;
       case "success":
+        return <WithdrawalSuccess transaction={successTransaction} />;
       case "error":
-        return <WithdrawalSuccess />;
+        return <WithdrawalErrorDisplay message={errorMessage} onRetry={() => close()} />;
       default:
         return <WithdrawalMethodSelect />;
     }
   };
+
+  function WithdrawalErrorDisplay({ message, onRetry }: { message: string | null; onRetry: () => void }) {
+    return (
+      <div className="p-6 space-y-6">
+        <div className="flex flex-col items-center pt-8 pb-4">
+          <div className="w-20 h-20 rounded-full flex items-center justify-center mb-4 bg-red-500/10">
+            <XCircle className="size-10 text-red-500" />
+          </div>
+          <h2 className="text-xl font-bold text-red-500">Withdrawal Failed</h2>
+          <p className="text-sm text-muted-foreground mt-1 text-center">
+            {message || "Something went wrong. Please try again."}
+          </p>
+        </div>
+        <div className="space-y-3 pt-2">
+          <button
+            onClick={onRetry}
+            className="w-full py-3.5 rounded-xl font-semibold bg-primary text-primary-foreground hover:bg-primary/90 active:scale-[0.98] transition-all duration-200"
+          >
+            Try Again
+          </button>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <>

--- a/components/dashboard/withdrawal/WithdrawalReview.tsx
+++ b/components/dashboard/withdrawal/WithdrawalReview.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { useState } from "react";
 import { useWithdrawalStore } from "@/hooks/useWithdrawalStore";
-import { ChevronLeft, Loader2, Coins, CircleDollarSign, BadgeDollarSign } from "lucide-react";
+import { ChevronLeft, Coins, CircleDollarSign, BadgeDollarSign } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { createWithdrawal } from "@/lib/api/transactions";
+import { WithdrawalConfirmationModal } from "@/components/dashboard/withdraw/withdrawal-confirmation-modal";
 
 const currencies = [
     { id: 'USDC', name: 'USD Coin', icon: <CircleDollarSign className="w-8 h-8 text-blue-500" /> },
@@ -13,8 +15,10 @@ const currencies = [
 
 export function WithdrawalReview() {
     const { currency, amount, walletAddress, step, setStep, setTransactionResult, close, reset } = useWithdrawalStore();
+    const [showConfirmation, setShowConfirmation] = useState(false);
+    const [isProcessing, setIsProcessing] = useState(false);
 
-    const isProcessing = step === 'processing';
+    const isProcessingStep = step === 'processing';
     const selectedCurrency = currencies.find(c => c.id === currency) || currencies[0];
 
     const truncateAddress = (addr: string) => {
@@ -22,14 +26,19 @@ export function WithdrawalReview() {
         return `${addr.slice(0, 8)}...${addr.slice(-6)}`;
     };
 
-    const handleConfirm = async () => {
+    const handleConfirmClick = () => {
+        setShowConfirmation(true);
+    };
+
+    const handleConfirmedWithdrawal = async () => {
+        setIsProcessing(true);
         setStep('processing');
 
         try {
             const response = await createWithdrawal({
                 currency,
-                amount: parseFloat(amount),
-                destinationAddress: walletAddress,
+                amount,
+                walletAddress,
             });
 
             setTransactionResult(response.transactionId, 'success');
@@ -40,31 +49,38 @@ export function WithdrawalReview() {
                 : 'An unexpected error occurred';
             setTransactionResult(null, 'failed', errorMessage);
             setStep('error');
+        } finally {
+            setIsProcessing(false);
+            setShowConfirmation(false);
         }
     };
 
     const handleCancel = () => {
-        if (isProcessing) return;
-        close();
-        setTimeout(() => reset(), 300);
-    };
-
-    const handleCancel = () => {
-        if (isProcessing) return;
+        if (isProcessingStep) return;
         close();
         setTimeout(() => reset(), 300);
     };
 
     return (
-        <div className="p-6 space-y-6">
+        <div className="p-6 space-y-6 relative">
+            {showConfirmation && (
+                <WithdrawalConfirmationModal
+                    amount={amount}
+                    currency={currency}
+                    destinationAddress={walletAddress}
+                    onConfirm={handleConfirmedWithdrawal}
+                    onCancel={() => setShowConfirmation(false)}
+                    isLoading={isProcessing}
+                />
+            )}
             {/* Header */}
             <div className="flex items-center gap-3 pt-4">
                 <button
                     onClick={() => setStep('form')}
-                    disabled={isProcessing}
+                    disabled={isProcessingStep}
                     className={cn(
                         "p-2 -ml-2 rounded-full hover:bg-muted transition-colors",
-                        isProcessing && "opacity-50 cursor-not-allowed"
+                        isProcessingStep && "opacity-50 cursor-not-allowed"
                     )}
                     aria-label="Go back to withdrawal form"
                 >
@@ -122,42 +138,35 @@ export function WithdrawalReview() {
             {/* Actions */}
             <div className="space-y-3 pt-2">
                 <button
-                    onClick={handleConfirm}
-                    disabled={isProcessing}
+                    onClick={handleConfirmClick}
+                    disabled={isProcessingStep}
                     className={cn(
                         "w-full py-3.5 rounded-xl font-semibold",
                         "bg-primary text-primary-foreground",
                         "hover:bg-primary/90 active:scale-[0.98]",
                         "transition-all duration-200",
                         "flex items-center justify-center gap-2",
-                        isProcessing && "opacity-80 cursor-not-allowed"
+                        isProcessingStep && "opacity-80 cursor-not-allowed"
                     )}
                 >
-                    {isProcessing ? (
-                        <>
-                            <Loader2 className="size-5 animate-spin" />
-                            Processing...
-                        </>
-                    ) : (
-                        "Confirm Withdrawal"
-                    )}
+                    Confirm Withdrawal
                 </button>
                 <button
                     onClick={() => setStep('form')}
-                    disabled={isProcessing}
+                    disabled={isProcessingStep}
                     className={cn(
                         "w-full py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors",
-                        isProcessing && "opacity-50 cursor-not-allowed"
+                        isProcessingStep && "opacity-50 cursor-not-allowed"
                     )}
                 >
                     Go Back
                 </button>
                 <button
                     onClick={handleCancel}
-                    disabled={isProcessing}
+                    disabled={isProcessingStep}
                     className={cn(
                         "w-full py-2 text-sm font-medium text-muted-foreground hover:text-foreground transition-colors",
-                        isProcessing && "opacity-50 cursor-not-allowed"
+                        isProcessingStep && "opacity-50 cursor-not-allowed"
                     )}
                 >
                     Cancel


### PR DESCRIPTION
## Summary

Adds a **confirmation step** before withdrawal submission and a **post-submission status screen** to the withdrawal flow. Withdrawals move real money — users must explicitly verify the full destination address before submission, and must be able to track the withdrawal status after submission.

## Changes

### New Files

| File | Description |
|---|---|
| `components/dashboard/withdraw/withdrawal-confirmation-modal.tsx` | Confirmation modal shown before the API call. Displays full destination address (not truncated), amount/currency, and an irreversibility warning. |
| `components/dashboard/withdraw/withdrawal-success.tsx` | Post-submission success screen showing transaction ID, amount, currency, destination address, and estimated processing time. |
| `components/dashboard/withdraw/index.ts` | Barrel export for the new components. |

### Modified Files

| File | Description |
|---|---|
| `components/dashboard/withdrawal/WithdrawalReview.tsx` | "Confirm Withdrawal" button now opens the confirmation modal instead of calling the API directly. API call only fires after user confirms in the modal. Fixed `CreateWithdrawalDto` params to match the actual type (`amount: string`, `walletAddress: string`). Removed duplicate `handleCancel` function. |
| `components/dashboard/withdrawal/WithdrawalModal.tsx` | Routes `success` step to the new `WithdrawalSuccess` component with a constructed `Transaction` object. Error state has its own inline error display with a "Try Again" button. |

## Flow

1. **Review step** — user reviews withdrawal details (amount, truncated address, fee)
2. **Confirmation modal** — user clicks "Confirm Withdrawal" → modal appears with **full destination address** and **irreversibility warning**
3. **API call** — "Confirm Withdrawal" in the modal triggers `POST /transactions/withdraw` with loading spinner
4. **Success screen** — on success, shows transaction details with "View in Transactions" and "Make Another Withdrawal" links (user controls next step)

## Acceptance Criteria

- [x] Confirmation modal appears before any API call
- [x] Full destination address visible in confirmation (not truncated)
- [x] Irreversibility warning present in the confirmation modal
- [x] Success screen appears after submission (not just a toast)
- [x] Success screen shows transaction ID and all relevant details
- [x] `npm run build` and `npm run lint` pass (pre-existing issues unrelated)

Closes #259
