### PR TITLE
Add cohort retention analytics table

### DIFF
--- a/app/(admin)/admin/analytics/page.test.tsx
+++ b/app/(admin)/admin/analytics/page.test.tsx
@@ -5,18 +5,21 @@ import AnalyticsPage from "./page";
 vi.mock("@/lib/api/admin", () => ({
   getAdminMetrics: vi.fn(),
   getAdminUsers: vi.fn(),
+  getCohortRetention: vi.fn(),
 }));
 
-import { getAdminMetrics, getAdminUsers } from "@/lib/api/admin";
+import { getAdminMetrics, getAdminUsers, getCohortRetention } from "@/lib/api/admin";
 
 describe("AnalyticsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(getCohortRetention).mockResolvedValue([]);
   });
 
   it("shows loading state initially", () => {
     vi.mocked(getAdminMetrics).mockReturnValue(new Promise(() => {}));
     vi.mocked(getAdminUsers).mockReturnValue(new Promise(() => {}));
+    vi.mocked(getCohortRetention).mockReturnValue(new Promise(() => {}));
     render(<AnalyticsPage />);
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
   });
@@ -40,6 +43,33 @@ describe("AnalyticsPage", () => {
     expect(screen.getByText("3,200")).toBeInTheDocument();
     expect(screen.getByText("12")).toBeInTheDocument();
     expect(screen.getByText("4")).toBeInTheDocument();
+  });
+
+  it("renders cohort retention data from API", async () => {
+    vi.mocked(getAdminMetrics).mockResolvedValue({
+      registeredUsers: 150,
+      totalTransactions: 3200,
+      pendingKyc: 12,
+      currencies: 4,
+      totalDeposits: 500000,
+      totalWithdrawals: 200000,
+    });
+    vi.mocked(getAdminUsers).mockResolvedValue({ data: [], total: 0 });
+    vi.mocked(getCohortRetention).mockResolvedValue([
+      {
+        cohortMonth: "2025-01",
+        cohortSize: 420,
+        retentionByMonth: [100, 72, 58],
+      },
+    ]);
+
+    render(<AnalyticsPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Cohort Retention")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Jan 2025")).toBeInTheDocument();
+    expect(screen.getByTitle("72% of Jan 2025 users were active in Month 2")).toBeInTheDocument();
   });
 
   it("shows error state on failure", async () => {

--- a/app/(admin)/admin/analytics/page.tsx
+++ b/app/(admin)/admin/analytics/page.tsx
@@ -1,10 +1,18 @@
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { ChevronDown, UserPlus, ArrowUpDown, Clock, Coins, Loader2 } from "lucide-react";
+import { ChevronDown, UserPlus, ArrowUpDown, Clock, Coins } from "lucide-react";
 import { AdminMetricCard } from "@/components/admin/AdminMetricCard";
+import { CohortRetentionTable } from "@/components/admin/cohort-retention-table";
 import dynamic from "next/dynamic";
-import { getAdminMetrics, getAdminUsers, type AdminMetrics, type AdminUser } from "@/lib/api/admin";
+import {
+  getAdminMetrics,
+  getAdminUsers,
+  getCohortRetention,
+  type AdminMetrics,
+  type AdminUser,
+  type CohortRetentionData,
+} from "@/lib/api/admin";
 import { getRequestErrorMessage, isOfflineError } from "@/lib/api-client";
 import { AdminMetricCardsSkeleton } from "@/components/shared/page-skeletons";
 
@@ -20,6 +28,7 @@ const RevenueChart = dynamic(() => import("@/components/admin/RevenueChart").the
 export default function AnalyticsPage() {
   const [metrics, setMetrics] = useState<AdminMetrics | null>(null);
   const [recentUsers, setRecentUsers] = useState<AdminUser[]>([]);
+  const [cohortRetention, setCohortRetention] = useState<CohortRetentionData[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [offlineNotice, setOfflineNotice] = useState<string | null>(null);
@@ -30,14 +39,16 @@ export default function AnalyticsPage() {
     async function loadData() {
       try {
         setLoading(true);
-        const [metricsData, usersData] = await Promise.all([
+        const [metricsData, usersData, cohortData] = await Promise.all([
           getAdminMetrics(),
           getAdminUsers({ page: 1, limit: 5 }),
+          getCohortRetention(),
         ]);
         hasCachedAnalyticsRef.current = true;
         setOfflineNotice(null);
         setMetrics(metricsData);
         setRecentUsers(usersData.data);
+        setCohortRetention(cohortData);
         setError(null);
       } catch (err: any) {
         console.error("Failed to load admin analytics data", err);
@@ -131,6 +142,8 @@ export default function AnalyticsPage() {
           </div>
         </div>
       </div>
+
+      <CohortRetentionTable cohorts={cohortRetention} />
 
       {/* Recent users table */}
       <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden">

--- a/components/admin/cohort-retention-table.tsx
+++ b/components/admin/cohort-retention-table.tsx
@@ -1,0 +1,96 @@
+import type { CohortRetentionData } from "@/lib/api/admin";
+
+type Props = {
+  cohorts: CohortRetentionData[];
+};
+
+function formatCohortMonth(value: string) {
+  const [year, month] = value.split("-");
+  if (!year || !month) return value;
+
+  const date = new Date(Number(year), Number(month) - 1, 1);
+  return date.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+}
+
+function getRetentionCellClass(value: number) {
+  if (value >= 80) return "bg-emerald-700 text-white";
+  if (value >= 60) return "bg-emerald-500 text-white";
+  if (value >= 40) return "bg-emerald-200 text-emerald-950";
+  if (value > 0) return "bg-amber-100 text-amber-900";
+  return "bg-gray-50 text-gray-400";
+}
+
+export function CohortRetentionTable({ cohorts }: Props) {
+  const maxMonths = Math.max(0, ...cohorts.map((cohort) => cohort.retentionByMonth.length));
+
+  if (cohorts.length === 0) {
+    return (
+      <div className="bg-white rounded-2xl border border-gray-200 p-6 text-sm text-gray-500">
+        No cohort retention data available.
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden">
+      <div className="px-6 py-5 border-b border-gray-100">
+        <h3 className="text-lg font-bold text-gray-900">Cohort Retention</h3>
+        <p className="text-sm text-gray-500 mt-1">
+          Data loaded from GET /admin/analytics/cohort-retention.
+        </p>
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[760px] text-sm">
+          <thead>
+            <tr className="border-b border-gray-100 bg-gray-50">
+              <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Cohort
+              </th>
+              <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                Size
+              </th>
+              {Array.from({ length: maxMonths }, (_, index) => (
+                <th
+                  key={index}
+                  className="px-3 py-3 text-center text-xs font-semibold uppercase tracking-wide text-gray-500"
+                >
+                  Month {index + 1}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {cohorts.map((cohort) => {
+              const label = formatCohortMonth(cohort.cohortMonth);
+
+              return (
+                <tr key={cohort.cohortMonth} className="border-b border-gray-50 last:border-0">
+                  <td className="px-6 py-4 font-semibold text-gray-900">{label}</td>
+                  <td className="px-4 py-4 text-gray-600">{cohort.cohortSize.toLocaleString()}</td>
+                  {Array.from({ length: maxMonths }, (_, index) => {
+                    const value = cohort.retentionByMonth[index];
+
+                    return (
+                      <td key={index} className="px-3 py-3 text-center">
+                        {value === undefined ? (
+                          <span className="text-gray-300">-</span>
+                        ) : (
+                          <span
+                            className={`inline-flex min-w-14 justify-center rounded px-2 py-1 font-semibold ${getRetentionCellClass(value)}`}
+                            title={`${value}% of ${label} users were active in Month ${index + 1}`}
+                          >
+                            {value}%
+                          </span>
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/lib/api/admin.ts
+++ b/lib/api/admin.ts
@@ -27,6 +27,12 @@ export interface AdminMetrics {
     totalWithdrawals: number;
 }
 
+export interface CohortRetentionData {
+    cohortMonth: string;
+    cohortSize: number;
+    retentionByMonth: number[];
+}
+
 export interface AdminTransaction {
     id: string;
     amount: number;
@@ -71,6 +77,23 @@ export async function getAdminMetrics(): Promise<AdminMetrics> {
         totalDeposits: response?.totalDeposits ?? response?.totalVolume ?? 0,
         totalWithdrawals: response?.totalWithdrawals ?? 0,
     };
+}
+
+export async function getCohortRetention(): Promise<CohortRetentionData[]> {
+    const response = await apiClient<any>('/admin/analytics/cohort-retention', {
+        method: 'GET',
+        headers: getAuthHeaders(),
+    });
+
+    const data = (response?.data ?? response?.cohorts ?? response?.items ?? (Array.isArray(response) ? response : [])) as any[];
+
+    return data.map((cohort: any) => ({
+        cohortMonth: cohort.cohortMonth ?? cohort.cohort_month ?? cohort.month ?? '',
+        cohortSize: Number(cohort.cohortSize ?? cohort.cohort_size ?? cohort.size) || 0,
+        retentionByMonth: (cohort.retentionByMonth ?? cohort.retention_by_month ?? cohort.retention ?? [])
+            .map((value: unknown) => Number(value))
+            .filter((value: number) => Number.isFinite(value)),
+    }));
 }
 
 export async function getAdminUsers(query: AdminUsersQuery = {}): Promise<{ data: AdminUser[]; total: number }> {


### PR DESCRIPTION
## Description
Adds a cohort retention API wrapper and heat-map table to the admin analytics page.

## Changes Implemented
- [x] Added GET /admin/analytics/cohort-retention integration.
- [x] Rendered cohort retention table with retention percentages and hover explanations.

## How to Test
1. Setup: Install dependencies.
2. Run Tests: npm run lint && npm run build.
3. Expected Output: Analytics loads the cohort retention table.

## Screenshots (if applicable)
N/A

## Checklist
- [x] Code follows project style guidelines.
- [ ] Changes are tested and verified.
- [ ] Documentation is updated (if needed).

## Related Issues
- Closes #511