### PR TITLE
fixed  createDeposit()

### DIFF
--- a/lib/api/transactions.ts
+++ b/lib/api/transactions.ts
@@ -252,10 +252,20 @@ export async function createWithdrawal(
 }
 
 // ==================== Deposit ====================
-
+//
+// Confirmed via live probe: POST /v1/transactions/deposit returns 401 (requires auth).
+// The backend could not be tested with a valid token (auth endpoints returning 500).
+//
+// Required fields (based on audit + Stellar convention):
+//   amount        — deposit amount as string
+//   currency      — currency code (e.g. "USDC")
+//   sourceAddress — the user's Stellar wallet public key; enables the backend to match
+//                   incoming on-chain transactions to this user's account.
+//                   Added as optional pending live verification.
 export interface CreateDepositDto {
     amount: string;
     currency: string;
+    sourceAddress?: string;
 }
 
 export interface DepositResponse {
@@ -266,12 +276,15 @@ export interface DepositResponse {
 }
 
 export async function createDeposit(
-    data: CreateDepositDto
+    { amount, currency, sourceAddress }: CreateDepositDto
 ): Promise<DepositResponse> {
+    const body: Record<string, string> = { amount, currency };
+    if (sourceAddress) body.sourceAddress = sourceAddress;
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const json = await apiClient<any>('/transactions/deposit', {
         method: 'POST',
-        body: JSON.stringify(data),
+        body: JSON.stringify(body),
     });
 
     // Normalize response - backend may use different field names

--- a/lib/api/users.ts
+++ b/lib/api/users.ts
@@ -1,5 +1,36 @@
 import { apiClient } from "@/lib/api-client";
 
+// ─── Profile ──────────────────────────────────────────────────────────────
+
+export interface UserProfile {
+  id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone?: string;
+  walletAddress?: string;
+  isVerified?: boolean;
+  avatarUrl?: string;
+}
+
+export interface UpdateProfileDto {
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+}
+
+export const getProfile = (): Promise<UserProfile> =>
+  apiClient('/users/profile', { useProxy: false });
+
+export const updateProfile = (data: UpdateProfileDto): Promise<UserProfile> =>
+  apiClient('/users/profile', {
+    method: 'PATCH',
+    body: JSON.stringify(data),
+    useProxy: false,
+  });
+
+// ─── Sessions ─────────────────────────────────────────────────────────────
+
 export interface UserSession {
   id: string;
   deviceInfo: string;


### PR DESCRIPTION
Here's a summary of what was done:
Changes Made
1. lib/api/users.ts — Added missing exports
- Added UserProfile interface (with id, firstName, lastName, email, phone?, walletAddress?, isVerified?, avatarUrl?)
- Added UpdateProfileDto interface
- Added getProfile() — GET /users/profile (was imported by 7 components but undefined)
- Added updateProfile() — PATCH /users/profile
2. lib/api/transactions.ts — Updated deposit DTO
- CreateDepositDto: Added sourceAddress?: string (the user's Stellar wallet public key, needed for the backend to match on-chain transactions)
- Documented the interface with a comment explaining the field requirements and the verification status
- createDeposit(): Updated to destructure sourceAddress and conditionally include it in the request body
Live Test Result
The backend at https://nexafx-backend.onrender.com/v1 is currently returning 500 errors on all auth endpoints (/auth/signup, /auth/login), so a valid auth token could not be obtained to confirm the DTO shape with a 2xx response. The sourceAddress field was added as optional based on:
- The audit finding that flagged it as the likely missing field
- Stellar blockchain convention (backend needs the sender's address to credit the user)
- The Transaction interface already carrying walletAddress
- Closes #169 
